### PR TITLE
🚀 feat(reset-password): Enhance CasaOS password reset script

### DIFF
--- a/reset-password-for-casaos/run.sh
+++ b/reset-password-for-casaos/run.sh
@@ -1,34 +1,84 @@
 #!/bin/bash
 # This script allows the user to reset their CasaOS username and password.
 
-# Check if the casaos.service is active
-if ! systemctl is-active --quiet casaos.service; then
-    echo "CasaOS service is not active. Exiting."
-    exit 1
+# Function to print headers
+print_header() {
+    echo "========================================"
+    echo "  $1"
+    echo "========================================"
+}
+
+# Function to check if a service is active
+check_service() {
+    if ! systemctl is-active --quiet "$1"; then
+        echo "Error: $1 service is not active. Please ensure CasaOS is properly installed and running."
+        exit 1
+    fi
+}
+
+# Function to backup the user database
+backup_user_db() {
+    local backup_file="/var/lib/casaos/db/user.db.backup_$(date +%Y%m%d_%H%M%S)"
+    if sudo cp /var/lib/casaos/db/user.db "$backup_file"; then
+        echo "User database backed up to $backup_file"
+    else
+        echo "Error: Failed to backup user database. Aborting."
+        exit 1
+    fi
+}
+
+# Check if script is run with sudo
+if [[ $EUID -ne 0 ]]; then
+   echo "This script must be run with sudo privileges. Aborting."
+   exit 1
 fi
 
+# Display Welcome
+print_header "BigBearCasaOS Password Reset V2.0"
+echo "Here are some links:"
+echo "https://community.bigbeartechworld.com"
+echo "https://github.com/BigBearTechWorld"
+echo ""
+echo "If you would like to support me, please consider buying me a tea:"
+echo "https://ko-fi.com/bigbeartechworld"
+echo ""
+
+# Check if the casaos service is active
+check_service "casaos.service"
+
 # Prompt user for confirmation
-read -p "Do you want to reset your CasaOS username and password? (y/n): " response
+read -p "Do you want to reset your CasaOS username and password? (y/N): " response
 
 # Check the user's response
-if [[ "$response" != "y" ]]; then
-    # If the user does not confirm, print a message and exit the script
-    echo "Script execution aborted."
-    exit 1
+if [[ "${response,,}" != "y" ]]; then
+    echo "Operation cancelled by user. Exiting."
+    exit 0
 fi
 
 # Check if user.db exists
 if [[ ! -f /var/lib/casaos/db/user.db ]]; then
-    # If the user database doesn't exist, print a message and exit the script
-    echo "user.db does not exist. Exiting."
+    echo "Error: user.db does not exist. Please ensure CasaOS is properly installed."
     exit 1
 fi
 
-# Backup user.db by moving it to a backup location
-sudo mv /var/lib/casaos/db/user.db /var/lib/casaos/db/user.db.backup
+# Backup user.db
+backup_user_db
+
+# Remove the original user.db
+if ! sudo rm /var/lib/casaos/db/user.db; then
+    echo "Error: Failed to remove original user.db. Aborting."
+    exit 1
+fi
 
 # Restart the casaos user service to reflect the changes
-sudo systemctl restart casaos-user-service.service
+if sudo systemctl restart casaos-user-service.service; then
+    echo "CasaOS user service restarted successfully."
+else
+    echo "Error: Failed to restart CasaOS user service. Please check the system logs."
+    exit 1
+fi
 
 # Print a success message to the user
-echo "Commands executed successfully. Visit CasaOS UI again and the welcome screen should present to reset password."
+print_header "Success"
+echo "Password reset process completed successfully."
+echo "Please visit the CasaOS UI. You should see the welcome screen to set up a new username and password."


### PR DESCRIPTION
This commit introduces several improvements to the CasaOS password reset script:

- Adds functions to print headers, check service status, and backup the user database.
- Checks if the script is run with sudo privileges.
- Displays a welcome message with links and information about supporting the project.
- Checks if the CasaOS service is active before proceeding.
- Prompts the user for confirmation before resetting the password.
- Backs up the user database before removing the original file.
- Restarts the CasaOS user service to reflect the changes.
- Provides clear success and error messages to the user.

These changes aim to make the password reset process more robust, user-friendly, and informative.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced output formatting with standardized header printing.
	- Added a service check to verify if specified services are active.
	- Introduced a backup process for user databases with timestamped files.

- **Improvements**
	- Improved error messages for better clarity.
	- Case-insensitive user confirmation prompts.
	- Ensured execution with necessary permissions before proceeding.

- **Bug Fixes**
	- Added error handling for service restarts and database deletion confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->