### PR TITLE
✨ feat(healthcheck): Add sudo check and improve version display

### DIFF
--- a/casaos-healthcheck/run.sh
+++ b/casaos-healthcheck/run.sh
@@ -326,6 +326,20 @@ check_docker_ports() {
     echo "      You can do this by running 'sudo ufw status verbose'"
 }
 
+# Check for sudo privileges
+if [ "$EUID" -ne 0 ]; then
+    print_color "0;33" "${WARNING_MARK} This script may require sudo privileges for full functionality."
+    echo "Some checks might fail or provide incomplete information without sudo."
+    echo "Consider running the script with sudo if you encounter permission-related issues."
+    echo
+    read -p "Do you want to continue without sudo? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        echo "Exiting. Please run the script again with sudo."
+        exit 1
+    fi
+fi
+
 # Main execution
 if [[ "$1" == "simulated_test" ]]; then
     echo "Running in simulated test mode..."
@@ -342,7 +356,7 @@ elif [[ "$1" == "real_test" ]]; then
 else
     # Normal script execution
     # Display Welcome
-    print_header "BigBearCasaOS Healthcheck V3.1"
+    print_header "BigBearCasaOS Healthcheck V3.2"
     echo "Here are some links:"
     echo "https://community.bigbeartechworld.com"
     echo "https://github.com/BigBearTechWorld"


### PR DESCRIPTION
This commit introduces the following changes:

- Checks if the script is running with sudo privileges. If not, it prompts the
  user to continue without sudo or exit the script.
- Updates the version display of the BigBearCasaOS Healthcheck to V3.2.

The sudo check is added to ensure that the script can perform all necessary
checks and provide complete information, as some checks may require elevated
privileges. The version update reflects the latest release of the healthcheck
tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a check for sudo privileges, enhancing user interaction and warning about potential incomplete checks.
	- Updated version number in the welcome message from "V3.1" to "V3.2".
	- Improved output structure for health check results, ensuring clearer messaging.

- **Bug Fixes**
	- Enhanced user experience by providing an option to exit if not running with sudo privileges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->