### PR TITLE
✨ feat: Improve portability of CasaOS healthcheck script

### DIFF
--- a/casaos-healthcheck/run.sh
+++ b/casaos-healthcheck/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Constants
 CONFIG_FILE="/etc/casaos/gateway.ini"


### PR DESCRIPTION
This pull request improves the portability of the CasaOS healthcheck script by replacing the hardcoded shebang `#!/bin/bash` with `#!/usr/bin/env bash`. This change ensures the script can be executed on systems where the Bash binary is not located at the default path `/bin/bash`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced health check script with additional checks for Docker status, storage health, disk space, CPU load, memory usage, system temperature, and system updates.
	- Improved output formatting for better readability, including colored status indicators.
	- Added user prompts for sudo privileges to inform users of potential limitations.

- **Bug Fixes**
	- Refined handling of service logs to differentiate between simulated and real logs for clearer output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->