### PR TITLE
Update run.sh to include lowercase I in hostname.

### DIFF
--- a/casaos-add-lan-ip-to-nextcloud-config/run.sh
+++ b/casaos-add-lan-ip-to-nextcloud-config/run.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Get the LAN IP address
-lan_ip=$(hostname -I | awk '{print $1}')
+lan_ip=$(hostname -i | awk '{print $1}')
 
 # Backup the original config.php file
 cp /DATA/AppData/big-bear-nextcloud/html/config/config.php /DATA/AppData/big-bear-nextcloud/html/config/config.php.bak


### PR DESCRIPTION
hostname -I is invalid. lowercase -i added to hostname to allow for proper execution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated IP address retrieval method for more precise LAN IP detection in Nextcloud configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->