### PR TITLE
✨ feat(setup-pterodactyl-wings): Use bash shebang for portability

### DIFF
--- a/setup-pterodactyl-wings/run.sh
+++ b/setup-pterodactyl-wings/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Crafted by BigBearTechWorld
 # Script to set up Pterodactyl server environment and networking


### PR DESCRIPTION
This pull request introduces a change to the `setup-pterodactyl-wings` script to improve its portability across different systems. The commit message describes the change in detail:

> ✨ feat(setup-pterodactyl-wings): Use bash shebang for
>
> portability
>
> Changes the shebang line from `#!/bin/bash` to `#!/usr/bin/env bash` to
> ensure the script runs on systems where the bash binary may not be
> located at `/bin/bash`.

The change ensures that the script can run on systems where the bash binary is not located at the default `/bin/bash` path, making the script more portable and reliable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated script interpreter declaration for improved cross-environment compatibility
	- Minor script portability enhancement for Bash execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->