### PR TITLE
🔧 fix(generate-romm-config/run.sh): Update URL to fetch Romm config

### DIFF
--- a/generate-romm-config/run.sh
+++ b/generate-romm-config/run.sh
@@ -21,7 +21,7 @@ fi
 mkdir -p "$(dirname "$location")"
 
 # Download the file from the given URL and save it to the specified location
-curl -L "https://raw.githubusercontent.com/bigbeartechworld/big-bear-casaos/master/Apps/Romm/config.yml" -o "$location"
+curl -L "https://raw.githubusercontent.com/bigbeartechworld/big-bear-casaos/refs/heads/master/Apps/romm/config.yml" -o "$location"
 
 # Confirm to the user
 echo "Config saved to $location"


### PR DESCRIPTION
**Pull Request Description:**

This pull request addresses an issue with the URL used to fetch the Romm configuration file in the `generate-romm-config/run.sh` script.

The changes update the URL to point to the correct location of the Romm configuration file on the master branch. The previous URL was outdated and pointing to an incorrect location, causing issues when trying to fetch the configuration.

The commit message provides more details on the changes made:

<###>🔧 fix(generate-romm-config/run.sh): Update URL to fetch Romm config

The changes update the URL used to fetch the Romm configuration file. The previous URL was pointing to an outdated location, so the new URL is updated to fetch the config from the correct location on the master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**  
  - Updated the configuration file download URL to use the correct directory casing and branch reference, ensuring reliable retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->