### PR TITLE
🎨 feat(generate-libredesk-config): Add script to generate LibreDesk config

### DIFF
--- a/generate-libredesk-config/README.md
+++ b/generate-libredesk-config/README.md
@@ -1,0 +1,5 @@
+# Run command
+
+```bash
+bash -c "$(wget -qLO - https://raw.githubusercontent.com/bigbeartechworld/big-bear-scripts/master/generate-romm-config/run.sh)"
+```

--- a/generate-libredesk-config/run.sh
+++ b/generate-libredesk-config/run.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Ask the user for the desired config location
+read -p "Enter the location to save the config (default: /DATA/AppData/big-bear-libredesk/config/config.yml): " location
+
+# If the user doesn't provide a location, default to the specified path
+if [ -z "$location" ]; then
+    location="/DATA/AppData/big-bear-libredesk/config/config.toml"
+fi
+
+# Check if the config file already exists
+if [ -e "$location" ]; then
+    read -p "Warning: $location already exists. Do you want to replace it? (yes/no) " replace
+    if [[ "$replace" != "yes" ]]; then
+        echo "Operation cancelled."
+        exit 1
+    fi
+fi
+
+# Create the directory (and its parents) if it doesn't exist
+mkdir -p "$(dirname "$location")"
+
+# Download the file from the given URL and save it to the specified location
+curl -L "https://raw.githubusercontent.com/bigbeartechworld/big-bear-casaos/refs/heads/master/Apps/libredesk/config.toml" -o "$location"
+
+# Confirm to the user
+echo "Config saved to $location"


### PR DESCRIPTION
**PR Description:**

This pull request adds a new script to generate a LibreDesk configuration file. The script prompts the user for the desired location to save the config file, and then downloads the default config from the BigBearTechWorld/big-bear-casaos repository and saves it to the specified location. If the file already exists, the user is asked for confirmation before overwriting it.

The changes include:

<###>🎨 feat(generate-libredesk-config): Add script to generate LibreDesk config

This commit adds a new script to generate a LibreDesk configuration file. The
script prompts the user for the desired location to save the config file, and
then downloads the default config from the BigBearTechWorld/big-bear-casaos
repository and saves it to the specified location. If the file already exists,
the user is asked for confirmation before overwriting it.
<###>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the project documentation with a new section detailing a terminal command to run the configuration process.
  
- **New Features**
  - Introduced a configuration utility that guides users through downloading and saving the application configuration file. It prompts for a file location, checks for existing files, creates necessary directories, and confirms successful configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->