### PR TITLE
📝 docs(reset-password-for-casaos): Add video link to README

### DIFF
--- a/reset-password-for-casaos/README.md
+++ b/reset-password-for-casaos/README.md
@@ -1,3 +1,7 @@
+# Video
+
+[![Watch the video](https://img.youtube.com/vi/m0Rsu9h7Z44/0.jpg)](https://youtu.be/m0Rsu9h7Z44)
+
 # Run command
 
 ```bash


### PR DESCRIPTION
# Add video link to README for reset-password-for-casaos

## Description
This pull request adds a video link to the README file for the `reset-password-for-casaos` feature. The video will provide users with a visual guide on how to reset their password for CasaOS.

## Changes
- Added a video link to the README file for the `reset-password-for-casaos` feature.

## Motivation
Providing a video guide will help users better understand the process of resetting their password for CasaOS, making the feature more accessible and user-friendly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new "Video" section to the README, featuring a header and a thumbnail image that links to a YouTube video for additional context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->