### PR TITLE
uninstall-docker-snap

### DIFF
--- a/install-casaos/run.sh
+++ b/install-casaos/run.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 #
 # This script includes functionality to automatically check SSL certificate validity.
 # SSL certificate verification will only be disabled if necessary for problematic domains.
@@ -522,9 +522,42 @@ Check_Docker_Install_Final() {
     fi
 }
 
+# Function to check and uninstall Docker from Snap
+Check_Docker_Snap() {
+    if command -v snap &> /dev/null && ${sudo_cmd} snap list docker &> /dev/null; then
+        Show 2 "Docker is installed via Snap."
+        echo -e "${aCOLOUR[4]}Snap-based Docker installations can cause compatibility issues with CasaOS.${COLOUR_RESET}"
+        echo -e "${aCOLOUR[4]}It's recommended to uninstall the Snap version before proceeding.${COLOUR_RESET}"
+
+        # Prompt for confirmation
+        read -p "Do you want to uninstall the Snap version of Docker? [y/n]: " yn
+        case $yn in
+            [Yy]*)
+                Show 2 "Uninstalling Docker from Snap..."
+                GreyStart
+                ${sudo_cmd} snap remove docker
+                ColorReset
+                Show 0 "Docker has been uninstalled from Snap."
+                ;;
+            [Nn]*)
+                Show 3 "Skipping Docker uninstallation from Snap. This may cause issues with CasaOS."
+                ;;
+            *)
+                Show 3 "Invalid response. Skipping Docker uninstallation from Snap."
+                ;;
+        esac
+    else
+        Show 2 "Docker is not installed via Snap, or Snap is not installed."
+    fi
+}
+
 #Install Docker
 Install_Docker() {
     Show 2 "Install the necessary dependencies: \e[33mDocker \e[0m"
+
+    # Check if Docker is installed via Snap and handle it
+    Check_Docker_Snap
+
     if [[ ! -d "${PREFIX}/etc/apt/sources.list.d" ]]; then
         ${sudo_cmd} mkdir -p "${PREFIX}/etc/apt/sources.list.d"
     fi

--- a/install-casaos/run.sh
+++ b/install-casaos/run.sh
@@ -32,7 +32,7 @@ NC='\033[0m' # No Color
 
 # Display Welcome
 echo -e "${BLUE}========================================${NC}"
-echo -e "${GREEN}BigBear CasaOS Installer V0.1${NC}"
+echo -e "${GREEN}BigBear CasaOS Installer V0.3${NC}"
 echo -e "${BLUE}========================================${NC}"
 echo "Here are some links:"
 echo "https://community.bigbeartechworld.com"


### PR DESCRIPTION
- Added a function to check and uninstall Docker installed via Snap, as Snap-based Docker installations can cause compatibility issues with CasaOS
- Updated the CasaOS Installer version from V0.1 to V0.3 to reflect the latest release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The installer now detects if Docker is installed via Snap and guides users through handling potential compatibility issues.
- **Improvements**
	- Updated installer version display from V0.1 to V0.3.
	- Enhanced script compatibility by updating the script's startup method for better portability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->