### PR TITLE
Fix docker permission with docker group

### DIFF
--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -20,7 +20,7 @@ else
 fi
 
 echo "=========================================="
-echo "BigBear CasaOS Docker Version Fix Script 1.1.0"
+echo "BigBear CasaOS Docker Version Fix Script 1.2.0"
 echo "=========================================="
 echo ""
 echo "Here are some links:"


### PR DESCRIPTION
This pull request updates the `casaos-fix-docker-api-version/run.sh` script to improve Docker permission handling, clarify cleanup steps, and streamline Docker directory management. The most significant changes introduce automatic user group configuration for Docker, simplify Docker runtime cleanup, and ensure Docker manages its own directory permissions on startup.

**Docker permissions and user management:**

* Added a new `add_user_to_docker_group` function that automatically adds the current non-root user to the `docker` group if needed, providing clear instructions for the user to re-login or use `newgrp` for the permission change to take effect. This function is now called as part of the main workflow. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaR127-R173) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaR877-R881)

**Docker runtime cleanup and permissions:**

* Refactored the `clean_docker_state` function to focus only on cleaning runtime state (such as sockets and pids), removing all manual Docker directory permission fixes and clarifying log messages. Now, Docker is relied upon to set its own directory permissions at startup. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL349-R398) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL361-R431)
* Removed manual permission fixes for the `overlay2` directory and other Docker directories from both the cleanup and downgrade steps, further delegating directory management to Docker itself. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL549-L559) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL725-R749)

**Service management improvements:**

* Updated the Docker service restart logic to explicitly enable both the `docker.socket` and `docker` services before starting them, improving reliability after changes.

**Other updates:**

* Incremented the script version number in the banner from 1.1.0 to 1.2.0.