### PR TITLE
Update Docker version handling for CasaOS compatibility

### DIFF
--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -20,7 +20,7 @@ else
 fi
 
 echo "=========================================="
-echo "BigBear CasaOS Docker Version Fix Script 1.3.0"
+echo "BigBear CasaOS Docker Version Fix Script 1.4.0"
 echo "=========================================="
 echo ""
 echo "Here are some links:"
@@ -34,10 +34,10 @@ echo "=========================================="
 echo ""
 
 # Compatible Docker versions for CasaOS
-# Using Docker 24.x series which supports API 1.43 (older CasaOS versions)
-# but is also compatible with API 1.44 (newer Docker daemons)
-readonly DOCKER_CE_VERSION="5:24.0.7-1~"
-readonly DOCKER_CLI_VERSION="5:24.0.7-1~"
+# Using Docker 24.0.x series which supports API 1.43
+# Docker 24.0.x is the last version series that provides API 1.43
+# (Docker 25.0+ uses API 1.44 and newer)
+readonly DOCKER_VERSION="5:24.0.*"
 # Using containerd.io 1.7.28-1 to avoid CVE-2025-52881 AppArmor issues in LXC/Proxmox
 # Version 1.7.28-2 and newer cause "permission denied" errors on sysctl in nested containers
 readonly CONTAINERD_VERSION="1.7.28-1"
@@ -79,6 +79,108 @@ detect_os() {
     exit 1
   fi
   echo "Detected OS: $OS ${VERSION_CODENAME}"
+  echo ""
+}
+
+# Function to check if Docker 24.0.x is available for this OS version
+check_docker_availability() {
+  echo "Checking Docker 24.0.x availability for $OS $VERSION_CODENAME..."
+  
+  # List of OS versions known to NOT have Docker 24.0.x packages
+  # Verified by checking actual package availability at https://download.docker.com/linux/
+  # Each entry includes the earliest Docker version available for that OS:
+  local unsupported_versions=(
+    "debian:trixie"   # Debian 13 - earliest version: Docker 28.0.0 (no 24.0.x available)
+    "ubuntu:noble"    # Ubuntu 24.04 - earliest version: Docker 26.0.0 (no 24.0.x available)
+    "ubuntu:oracular" # Ubuntu 24.10 - earliest version: Docker 27.3.0 (no 24.0.x available)
+  )
+  
+  # Known supported versions (have Docker 24.0.x available):
+  # - Ubuntu 20.04 (focal)
+  # - Ubuntu 22.04 (jammy)
+  # - Debian 11 (bullseye)
+  # - Debian 12 (bookworm)
+  
+  local current_os="${OS}:${VERSION_CODENAME}"
+  
+  for unsupported in "${unsupported_versions[@]}"; do
+    if [ "$current_os" = "$unsupported" ]; then
+      echo ""
+      echo "=========================================="
+      echo "ERROR: Unsupported OS Version Detected"
+      echo "=========================================="
+      echo ""
+      echo "Your system: $OS $VERSION_CODENAME"
+      echo ""
+      echo "Docker 24.0.x is NOT available for your OS version."
+      echo "The Docker repository for $VERSION_CODENAME only provides Docker 28.x and newer."
+      echo ""
+      echo "This script is designed to install Docker 24.0.x for CasaOS compatibility."
+      echo ""
+      echo "=========================================="
+      echo "Recommended Solutions:"
+      echo "=========================================="
+      echo ""
+      
+      if [ "$OS" = "debian" ] && [ "$VERSION_CODENAME" = "trixie" ]; then
+        echo "For Debian trixie (testing) users:"
+        echo ""
+        echo "  Option 1: Downgrade to Debian bookworm (stable)"
+        echo "    Debian trixie is the testing branch. Consider using Debian 12 (bookworm)"
+        echo "    which is the current stable release and fully supports Docker 24.0.7."
+        echo ""
+        echo "  Option 2: Install latest CasaOS (if available)"
+        echo "    Check if a newer version of CasaOS supports Docker 28.x:"
+        echo "    https://github.com/IceWhaleTech/CasaOS"
+        echo ""
+        echo "  Option 3: Manual Docker installation"
+        echo "    Install Docker 28.x and manually configure CasaOS to work with it."
+        echo "    Note: This may require CasaOS code modifications."
+        echo ""
+        
+        if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null || grep -q "BCM" /proc/cpuinfo 2>/dev/null; then
+          echo "  Option 4: For Raspberry Pi - Use Raspberry Pi OS based on bookworm"
+          echo "    The latest stable Raspberry Pi OS should be based on Debian bookworm,"
+          echo "    not trixie. Consider reinstalling with the stable release."
+          echo ""
+        fi
+      elif [[ "$VERSION_CODENAME" == "noble" ]] || [[ "$VERSION_CODENAME" == "oracular" ]]; then
+        echo "For Ubuntu 24.04+ users:"
+        echo ""
+        echo "  Option 1: Use Ubuntu 22.04 LTS (Jammy)"
+        echo "    Ubuntu 22.04 LTS is fully supported and has Docker 24.0.x available."
+        echo ""
+        echo "  Option 2: Install latest CasaOS (if available)"
+        echo "    Check if a newer version of CasaOS supports Docker 28.x:"
+        echo "    https://github.com/IceWhaleTech/CasaOS"
+        echo ""
+        echo "  Option 3: Manual Docker installation"
+        echo "    Install Docker 28.x and manually configure CasaOS to work with it."
+        echo ""
+      fi
+      
+      echo "=========================================="
+      echo "Why This Matters:"
+      echo "=========================================="
+      echo ""
+      echo "CasaOS requires Docker API version 1.43, which is provided by Docker 24.0.x."
+      echo "Docker 24.0.x is the last version series that supports API 1.43."
+      echo "Newer Docker versions (25.x+) use API version 1.44+, which may not be"
+      echo "compatible with older CasaOS installations."
+      echo ""
+      echo "Mixing package repositories from different OS versions can cause"
+      echo "system instability and is not recommended."
+      echo ""
+      echo "For more information:"
+      echo "  • CasaOS Issues: https://github.com/IceWhaleTech/CasaOS/issues"
+      echo "  • Community Forum: https://community.bigbeartechworld.com"
+      echo ""
+      
+      exit 1
+    fi
+  done
+  
+  echo "✓ Docker 24.0.x should be available for your OS version"
   echo ""
 }
 
@@ -248,7 +350,7 @@ verify_dockerd_binary_version() {
   local dockerd_version=$(dockerd --version 2>/dev/null | head -n1)
   echo "dockerd binary version: $dockerd_version"
   
-  # Check if it contains "24.0"
+  # Check if it contains "24.0" (accepts both 24.0.7 and 24.0.9)
   if echo "$dockerd_version" | grep -q "24.0"; then
     echo "✓ dockerd binary is version 24.0.x"
     echo ""
@@ -743,12 +845,9 @@ downgrade_docker() {
     echo ""
   fi
 
-  # Install specific Docker version compatible with CasaOS
-  echo "Installing Docker version compatible with CasaOS (24.0.7)..."
+  # Install latest Docker 24.0.x version compatible with CasaOS
+  echo "Installing latest Docker 24.0.x version compatible with CasaOS..."
   
-  ARCH=$(dpkg --print-architecture)
-  DOCKER_CE_FULL="${DOCKER_CE_VERSION}${OS}~${VERSION_CODENAME}"
-  DOCKER_CLI_FULL="${DOCKER_CLI_VERSION}${OS}~${VERSION_CODENAME}"
   CONTAINERD_FULL="${CONTAINERD_VERSION}~${OS}~${VERSION_CODENAME}"
   
   # Check if we're in LXC and warn about containerd version
@@ -766,45 +865,36 @@ downgrade_docker() {
     echo ""
   fi
   
-  echo "Installing docker-ce-cli=${DOCKER_CLI_FULL}"
-  echo "Installing docker-ce=${DOCKER_CE_FULL}"
+  # Install latest 24.0.x version available
+  echo "Installing docker-ce=${DOCKER_VERSION}"
+  echo "Installing docker-ce-cli=${DOCKER_VERSION}"
   echo "Installing containerd.io=${CONTAINERD_FULL}"
   echo ""
   
   if ! $SUDO apt-get install -y --allow-downgrades \
-    docker-ce-cli=${DOCKER_CLI_FULL} \
-    docker-ce=${DOCKER_CE_FULL} \
+    docker-ce=${DOCKER_VERSION} \
+    docker-ce-cli=${DOCKER_VERSION} \
     containerd.io=${CONTAINERD_FULL} \
     docker-buildx-plugin \
     docker-compose-plugin; then
+      # Fallback: try with pattern match for containerd if exact version fails
       echo ""
-      echo "Specific version installation failed. Trying alternative method..."
+      echo "Exact containerd version not found, trying version pattern..."
       echo ""
-      
-      # Fallback: try without the full version string but keep containerd specific
       if ! $SUDO apt-get install -y --allow-downgrades \
-        docker-ce=5:24.0.* \
-        docker-ce-cli=5:24.0.* \
-        containerd.io=${CONTAINERD_FULL} \
+        docker-ce=${DOCKER_VERSION} \
+        docker-ce-cli=${DOCKER_VERSION} \
+        containerd.io=1.7.28-1* \
         docker-buildx-plugin \
         docker-compose-plugin; then
-          # Last resort: try with pattern match for containerd
           echo ""
-          echo "Trying with containerd.io version pattern..."
-          echo ""
-          if ! $SUDO apt-get install -y --allow-downgrades \
-            docker-ce=5:24.0.* \
-            docker-ce-cli=5:24.0.* \
-            containerd.io=1.7.28-1* \
-            docker-buildx-plugin \
-            docker-compose-plugin; then
-              echo ""
-              echo "ERROR: All installation methods failed!"
-              echo "Please check your internet connection and try again."
-              return 1
-          fi
+          echo "ERROR: Docker installation failed!"
+          echo "Please check your internet connection and try again."
+          return 1
       fi
   fi
+  
+  echo "✓ Successfully installed Docker 24.0.x"
   echo ""
 
   # Hold packages to prevent auto-upgrade
@@ -1071,7 +1161,10 @@ main() {
   check_sudo
   detect_os
   
-  echo "Step 1a: Checking for Snap Docker installation..."
+  echo "Step 1a: Verifying Docker 24.0.x availability..."
+  check_docker_availability
+  
+  echo "Step 1b: Checking for Snap Docker installation..."
   if ! check_and_remove_snap_docker; then
     echo "=========================================="
     echo "ERROR: Failed to remove Snap Docker"
@@ -1084,7 +1177,7 @@ main() {
     exit 1
   fi
   
-  echo "Step 1b: Checking for multiple Docker binaries..."
+  echo "Step 1c: Checking for multiple Docker binaries..."
   check_docker_binary_locations
   
   echo "Step 2: Checking for CasaOS..."
@@ -1232,7 +1325,7 @@ main() {
     echo ""
     echo "  1. Verify the dockerd binary was actually replaced:"
     echo "     dockerd --version"
-    echo "     (Should show version 24.0.7)"
+    echo "     (Should show version 24.0.x)"
     echo ""
     echo "  2. Manually restart Docker to ensure new binary loads:"
     echo "     sudo systemctl stop docker"
@@ -1246,7 +1339,7 @@ main() {
     echo ""
     echo "  4. Verify package installation succeeded:"
     echo "     dpkg -l | grep docker-ce"
-    echo "     (Should show version 5:24.0.7-1~...)"
+    echo "     (Should show version 5:24.0.x-1~...)"
     echo ""
     echo "  5. Check Docker daemon logs for errors:"
     echo "     sudo journalctl -u docker --no-pager -n 50"
@@ -1264,7 +1357,7 @@ main() {
     echo "CasaOS Docker Fix Complete!"
     echo "=========================================="
     echo ""
-    echo "Docker has been set to version 24.0.7 (compatible with CasaOS)"
+    echo "Docker has been set to version 24.0.x (compatible with CasaOS)"
     echo "Docker packages have been held to prevent automatic upgrades."
     echo ""
     echo "To allow Docker to be upgraded in the future, run:"
@@ -1275,7 +1368,7 @@ main() {
     echo ""
   else
     echo "=========================================="
-    echo "Docker version has been set to 24.0.7"
+    echo "Docker version has been set to 24.0.x"
     echo "This version is compatible with CasaOS API 1.43"
     echo "=========================================="
     echo ""

--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -124,11 +124,11 @@ check_docker_availability() {
       
       if [ "$OS" = "debian" ] && [ "$VERSION_CODENAME" = "trixie" ]; then
         echo "For Debian trixie (testing) users:"
-        echo ""
-        echo "  Option 1: Downgrade to Debian bookworm (stable)"
-        echo "    Debian trixie is the testing branch. Consider using Debian 12 (bookworm)"
-        echo "    which is the current stable release and fully supports Docker 24.0.7."
-        echo ""
+      echo ""
+      echo "  Option 1: Downgrade to Debian bookworm (stable)"
+      echo "    Debian trixie is the testing branch. Consider using Debian 12 (bookworm)"
+      echo "    which is the current stable release and fully supports Docker 24.0.x."
+      echo ""
         echo "  Option 2: Install latest CasaOS (if available)"
         echo "    Check if a newer version of CasaOS supports Docker 28.x:"
         echo "    https://github.com/IceWhaleTech/CasaOS"
@@ -139,9 +139,9 @@ check_docker_availability() {
         echo ""
         
         if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null || grep -q "BCM" /proc/cpuinfo 2>/dev/null; then
-          echo "  Option 4: For Raspberry Pi - Use Raspberry Pi OS based on bookworm"
-          echo "    The latest stable Raspberry Pi OS should be based on Debian bookworm,"
-          echo "    not trixie. Consider reinstalling with the stable release."
+          echo "  Option 4: For Raspberry Pi - Reinstall with Raspberry Pi OS (Debian bookworm)"
+          echo "    The latest stable Raspberry Pi OS should be based on Debian bookworm (stable),"
+          echo "    not trixie. Consider reinstalling with Raspberry Pi OS based on Debian bookworm."
           echo ""
         fi
       elif [[ "$VERSION_CODENAME" == "noble" ]] || [[ "$VERSION_CODENAME" == "oracular" ]]; then


### PR DESCRIPTION
This pull request updates the CasaOS Docker Version Fix Script to improve compatibility checks and installation robustness for Docker 24.0.x. The script now verifies Docker 24.0.x package availability for the user's OS version, installs the latest matching version rather than a hardcoded one, and provides clearer messaging and fallback logic during installation. These changes help prevent installation on unsupported OS versions and ensure users receive the most compatible Docker release for CasaOS.

**Compatibility and OS Detection Improvements:**
* Added the `check_docker_availability` function to detect if Docker 24.0.x is available for the user's OS version (Debian trixie, Ubuntu noble/oracular are now flagged as unsupported), with detailed error messages and recommended solutions. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaR85-R186) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1074-R1167)
* Updated script messaging and step order to verify Docker version availability before proceeding with other checks. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1074-R1167) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1087-R1180)

**Installation Logic Enhancements:**
* Changed version variables to use a pattern (`5:24.0.*`) for installing the latest available Docker 24.0.x, and updated installation commands and fallback logic to match any suitable 24.0.x version. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL37-R40) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL746-L751) [[3]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL769-R897)
* Improved fallback handling for `containerd.io` installation, trying version patterns if exact matches fail, and clarified error messaging for failed installations.

**Messaging and Documentation Updates:**
* Updated all user-facing messages, instructions, and version references to refer to "Docker 24.0.x" instead of the specific "24.0.7" version, reflecting the more flexible installation logic. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL23-R23) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL251-R353) [[3]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1235-R1328) [[4]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1249-R1342) [[5]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1267-R1360) [[6]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1278-R1371)