### PR TITLE
Add Docker API override method for newer distros

### DIFF
--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -1302,7 +1302,7 @@ main() {
     case "$1" in
       apply-override|override)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 1.4.0"
+        echo "BigBear CasaOS Docker Version Fix Script 1.5.0"
         echo "=========================================="
         echo ""
         apply_docker_api_override
@@ -1310,7 +1310,7 @@ main() {
         ;;
       remove-override|no-override)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 1.4.0"
+        echo "BigBear CasaOS Docker Version Fix Script 1.5.0"
         echo "=========================================="
         echo ""
         remove_docker_api_override
@@ -1318,7 +1318,7 @@ main() {
         ;;
       help|--help|-h)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 1.4.0"
+        echo "BigBear CasaOS Docker Version Fix Script 1.5.0"
         echo "=========================================="
         echo ""
         show_usage

--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -20,7 +20,7 @@ else
 fi
 
 echo "=========================================="
-echo "BigBear CasaOS Docker Version Fix Script 1.4.0"
+echo "BigBear CasaOS Docker Version Fix Script 1.5.0"
 echo "=========================================="
 echo ""
 echo "Here are some links:"
@@ -87,8 +87,7 @@ check_docker_availability() {
   echo "Checking Docker 24.0.x availability for $OS $VERSION_CODENAME..."
   
   # List of OS versions known to NOT have Docker 24.0.x packages
-  # Verified by checking actual package availability at https://download.docker.com/linux/
-  # Each entry includes the earliest Docker version available for that OS:
+  # For these, we'll use the Docker API override method instead
   local unsupported_versions=(
     "debian:trixie"   # Debian 13 - earliest version: Docker 28.0.0 (no 24.0.x available)
     "ubuntu:noble"    # Ubuntu 24.04 - earliest version: Docker 26.0.0 (no 24.0.x available)
@@ -107,81 +106,30 @@ check_docker_availability() {
     if [ "$current_os" = "$unsupported" ]; then
       echo ""
       echo "=========================================="
-      echo "ERROR: Unsupported OS Version Detected"
+      echo "Newer Distribution Detected"
       echo "=========================================="
       echo ""
       echo "Your system: $OS $VERSION_CODENAME"
       echo ""
       echo "Docker 24.0.x is NOT available for your OS version."
-      echo "The Docker repository for $VERSION_CODENAME only provides Docker 28.x and newer."
+      echo "The Docker repository for $VERSION_CODENAME only provides Docker 26.x and newer."
       echo ""
-      echo "This script is designed to install Docker 24.0.x for CasaOS compatibility."
+      echo "This script will use the Docker API override method instead:"
+      echo "  • Sets DOCKER_MIN_API_VERSION=1.24 environment variable"
+      echo "  • Allows newer Docker versions (26.x, 27.x, 28.x, 29.x) to work with CasaOS"
+      echo "  • Does not require downgrading Docker"
       echo ""
-      echo "=========================================="
-      echo "Recommended Solutions:"
-      echo "=========================================="
-      echo ""
-      
-      if [ "$OS" = "debian" ] && [ "$VERSION_CODENAME" = "trixie" ]; then
-        echo "For Debian trixie (testing) users:"
-      echo ""
-      echo "  Option 1: Downgrade to Debian bookworm (stable)"
-      echo "    Debian trixie is the testing branch. Consider using Debian 12 (bookworm)"
-      echo "    which is the current stable release and fully supports Docker 24.0.x."
-      echo ""
-        echo "  Option 2: Install latest CasaOS (if available)"
-        echo "    Check if a newer version of CasaOS supports Docker 28.x:"
-        echo "    https://github.com/IceWhaleTech/CasaOS"
-        echo ""
-        echo "  Option 3: Manual Docker installation"
-        echo "    Install Docker 28.x and manually configure CasaOS to work with it."
-        echo "    Note: This may require CasaOS code modifications."
-        echo ""
-        
-        if grep -q "Raspberry Pi" /proc/cpuinfo 2>/dev/null || grep -q "BCM" /proc/cpuinfo 2>/dev/null; then
-          echo "  Option 4: For Raspberry Pi - Reinstall with Raspberry Pi OS (Debian bookworm)"
-          echo "    The latest stable Raspberry Pi OS should be based on Debian bookworm (stable),"
-          echo "    not trixie. Consider reinstalling with Raspberry Pi OS based on Debian bookworm."
-          echo ""
-        fi
-      elif [[ "$VERSION_CODENAME" == "noble" ]] || [[ "$VERSION_CODENAME" == "oracular" ]]; then
-        echo "For Ubuntu 24.04+ users:"
-        echo ""
-        echo "  Option 1: Use Ubuntu 22.04 LTS (Jammy)"
-        echo "    Ubuntu 22.04 LTS is fully supported and has Docker 24.0.x available."
-        echo ""
-        echo "  Option 2: Install latest CasaOS (if available)"
-        echo "    Check if a newer version of CasaOS supports Docker 28.x:"
-        echo "    https://github.com/IceWhaleTech/CasaOS"
-        echo ""
-        echo "  Option 3: Manual Docker installation"
-        echo "    Install Docker 28.x and manually configure CasaOS to work with it."
-        echo ""
-      fi
-      
-      echo "=========================================="
-      echo "Why This Matters:"
-      echo "=========================================="
-      echo ""
-      echo "CasaOS requires Docker API version 1.43, which is provided by Docker 24.0.x."
-      echo "Docker 24.0.x is the last version series that supports API 1.43."
-      echo "Newer Docker versions (25.x+) use API version 1.44+, which may not be"
-      echo "compatible with older CasaOS installations."
-      echo ""
-      echo "Mixing package repositories from different OS versions can cause"
-      echo "system instability and is not recommended."
-      echo ""
-      echo "For more information:"
-      echo "  • CasaOS Issues: https://github.com/IceWhaleTech/CasaOS/issues"
-      echo "  • Community Forum: https://community.bigbeartechworld.com"
+      echo "This is a safe alternative that maintains compatibility with CasaOS."
       echo ""
       
-      exit 1
+      # Return a special status code to indicate we should use the override method
+      return 2
     fi
   done
   
   echo "✓ Docker 24.0.x should be available for your OS version"
   echo ""
+  return 0
 }
 
 # Function to check for and remove Snap Docker installation
@@ -518,6 +466,127 @@ start_casaos_services() {
     fi
   done
   echo ""
+}
+
+# Function to apply Docker API override (alternative fix for newer distros)
+apply_docker_api_override() {
+  echo "=========================================="
+  echo "Applying Docker API Override Configuration"
+  echo "=========================================="
+  echo ""
+  echo "This sets DOCKER_MIN_API_VERSION=1.24 to allow older CasaOS versions"
+  echo "to work with newer Docker versions (27.x, 28.x, 29.x)"
+  echo ""
+  echo "Use this method on distributions where Docker 24.0.x is not available:"
+  echo "  - Ubuntu 24.04 (noble)"
+  echo "  - Ubuntu 24.10 (oracular)"
+  echo "  - Debian 13 (trixie)"
+  echo ""
+  
+  local override_dir="/etc/systemd/system/docker.service.d"
+  local override_file="$override_dir/override.conf"
+  
+  # Create directory if it doesn't exist
+  if [ ! -d "$override_dir" ]; then
+    echo "Creating directory: $override_dir"
+    $SUDO mkdir -p "$override_dir"
+  fi
+  
+  # Create or update override.conf
+  echo "Creating Docker service override configuration..."
+  $SUDO tee "$override_file" > /dev/null <<'EOF'
+[Service]
+Environment=DOCKER_MIN_API_VERSION=1.24
+EOF
+  
+  if [ -f "$override_file" ]; then
+    echo "✓ Created: $override_file"
+    echo ""
+    echo "Contents:"
+    $SUDO cat "$override_file" | sed 's/^/  /'
+    echo ""
+  else
+    echo "ERROR: Failed to create override file"
+    return 1
+  fi
+  
+  # Reload systemd daemon
+  echo "Reloading systemd daemon..."
+  $SUDO systemctl daemon-reload
+  echo ""
+  
+  # Restart Docker
+  echo "Restarting Docker service..."
+  $SUDO systemctl restart docker
+  sleep 3
+  echo ""
+  
+  # Verify Docker is running
+  if $SUDO systemctl is-active --quiet docker; then
+    echo "✓ Docker service restarted successfully"
+    
+    # Show current Docker info
+    local docker_version=$(get_docker_api_version)
+    if command -v docker &>/dev/null; then
+      local docker_ver=$($SUDO docker version --format '{{.Server.Version}}' 2>/dev/null || echo "unknown")
+      echo ""
+      echo "Current configuration:"
+      echo "  Docker version: $docker_ver"
+      echo "  API version:    $docker_version"
+      echo ""
+    fi
+    
+    echo "✓ Docker API override applied successfully!"
+    echo "CasaOS should now work with this Docker version"
+    echo ""
+    return 0
+  else
+    echo "ERROR: Docker service failed to start after applying override"
+    echo ""
+    echo "Check logs with: sudo journalctl -u docker -n 50"
+    return 1
+  fi
+}
+
+# Function to remove Docker API override
+remove_docker_api_override() {
+  echo "=========================================="
+  echo "Removing Docker API Override Configuration"
+  echo "=========================================="
+  echo ""
+  
+  local override_file="/etc/systemd/system/docker.service.d/override.conf"
+  
+  if [ ! -f "$override_file" ]; then
+    echo "No override configuration found"
+    echo ""
+    return 0
+  fi
+  
+  echo "Removing: $override_file"
+  $SUDO rm -f "$override_file"
+  
+  # Reload systemd daemon
+  echo "Reloading systemd daemon..."
+  $SUDO systemctl daemon-reload
+  echo ""
+  
+  # Restart Docker
+  echo "Restarting Docker service..."
+  $SUDO systemctl restart docker
+  sleep 3
+  echo ""
+  
+  if $SUDO systemctl is-active --quiet docker; then
+    echo "✓ Docker API override removed successfully"
+    echo ""
+    return 0
+  else
+    echo "WARNING: Docker service may have issues after removing override"
+    echo "Check logs with: sudo journalctl -u docker -n 50"
+    echo ""
+    return 1
+  fi
 }
 
 # Function to validate daemon.json
@@ -1200,14 +1269,393 @@ downgrade_docker() {
   echo ""
 }
 
+# Function to show usage information
+show_usage() {
+  echo "Usage: $0 [command]"
+  echo ""
+  echo "Commands:"
+  echo "  (no arguments)      - Run the full Docker downgrade fix (default)"
+  echo "  apply-override      - Apply Docker API override (for newer distros)"
+  echo "  remove-override     - Remove Docker API override configuration"
+  echo "  help                - Show this help message"
+  echo ""
+  echo "Default behavior (no arguments):"
+  echo "  Downgrades Docker to version 24.0.x (compatible with CasaOS)"
+  echo "  Use on: Ubuntu 20.04, 22.04, Debian 11, 12"
+  echo ""
+  echo "Alternative fix (apply-override):"
+  echo "  Sets DOCKER_MIN_API_VERSION=1.24 environment variable"
+  echo "  Allows newer Docker versions (27.x, 28.x, 29.x) to work with CasaOS"
+  echo "  Use on: Ubuntu 24.04+, Debian trixie, or other distros without Docker 24.0.x"
+  echo ""
+  echo "Examples:"
+  echo "  $0                  # Run the downgrade fix (default)"
+  echo "  $0 apply-override   # Apply API override for newer distros"
+  echo "  $0 remove-override  # Remove API override"
+  echo ""
+}
+
 # Main function
 main() {
+  # Handle command-line arguments
+  if [ $# -gt 0 ]; then
+    case "$1" in
+      apply-override|override)
+        echo "=========================================="
+        echo "BigBear CasaOS Docker Version Fix Script 1.4.0"
+        echo "=========================================="
+        echo ""
+        apply_docker_api_override
+        exit $?
+        ;;
+      remove-override|no-override)
+        echo "=========================================="
+        echo "BigBear CasaOS Docker Version Fix Script 1.4.0"
+        echo "=========================================="
+        echo ""
+        remove_docker_api_override
+        exit $?
+        ;;
+      help|--help|-h)
+        echo "=========================================="
+        echo "BigBear CasaOS Docker Version Fix Script 1.4.0"
+        echo "=========================================="
+        echo ""
+        show_usage
+        exit 0
+        ;;
+      *)
+        echo "ERROR: Unknown command: $1"
+        echo ""
+        show_usage
+        exit 1
+        ;;
+    esac
+  fi
+  
   echo "Step 1: Checking system..."
   check_sudo
   detect_os
   
   echo "Step 1a: Verifying Docker 24.0.x availability..."
   check_docker_availability
+  local availability_result=$?
+  
+  # If return code is 2, Docker 24.0.x is not available - use override method
+  if [ $availability_result -eq 2 ]; then
+    echo "Proceeding with Docker API override method..."
+    echo ""
+    
+    # Check if Docker is installed
+    if ! command -v docker &>/dev/null; then
+      echo "Docker is not installed. Installing latest Docker version..."
+      echo ""
+      
+      # Set up Docker repository and install latest version
+      echo "Setting up Docker repository..."
+      
+      # Clean up any existing Docker repository configurations
+      if [ -f /etc/apt/sources.list.d/docker.list ]; then
+        $SUDO rm -f /etc/apt/sources.list.d/docker.list
+      fi
+      
+      $SUDO apt-get update
+      echo ""
+      
+      echo "Installing prerequisites..."
+      $SUDO apt-get install -y \
+        apt-transport-https \
+        ca-certificates \
+        curl \
+        gnupg \
+        lsb-release
+      echo ""
+      
+      # Add Docker's official GPG key
+      echo "Adding Docker's official GPG key..."
+      $SUDO install -m 0755 -d /etc/apt/keyrings
+      $SUDO curl -fsSL https://download.docker.com/linux/${OS}/gpg -o /etc/apt/keyrings/docker.asc
+      $SUDO chmod a+r /etc/apt/keyrings/docker.asc
+      echo ""
+      
+      # Set up the stable repository
+      echo "Setting up Docker repository..."
+      echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${OS} \
+        ${VERSION_CODENAME} stable" | \
+        $SUDO tee /etc/apt/sources.list.d/docker.list > /dev/null
+      echo ""
+      
+      # Update package index
+      echo "Updating package lists..."
+      $SUDO apt-get update
+      echo ""
+      
+      # Check if we're in LXC to determine containerd version
+      local containerd_spec="containerd.io"
+      if check_lxc_environment; then
+        echo ""
+        echo "=========================================="
+        echo "LXC/Proxmox Environment Detected"
+        echo "=========================================="
+        echo ""
+        echo "Installing containerd.io ${CONTAINERD_VERSION} to avoid CVE-2025-52881 AppArmor issues."
+        echo "This version is safe and prevents 'permission denied' errors on sysctl."
+        echo ""
+        echo "For more information, see:"
+        echo "https://github.com/opencontainers/runc/issues/4968"
+        echo ""
+        
+        # Resolve exact containerd version
+        CONTAINERD_FULL="${CONTAINERD_VERSION}~${OS}~${VERSION_CODENAME}"
+        
+        # Verify containerd version exists
+        if ! apt-cache madison containerd.io 2>/dev/null | grep -q "${CONTAINERD_FULL}"; then
+          echo "Exact containerd version ${CONTAINERD_FULL} not found"
+          echo "Searching for any 1.7.28-1 variant..."
+          CONTAINERD_FULL=$(apt-cache madison containerd.io 2>/dev/null | \
+            grep -E '1\.7\.28-1~' | \
+            head -n1 | \
+            awk '{print $3}')
+          
+          if [ -z "$CONTAINERD_FULL" ]; then
+            echo "ERROR: Could not find containerd.io 1.7.28-1 in repository"
+            echo "Available containerd.io versions:"
+            apt-cache madison containerd.io 2>/dev/null | head -n 5
+            echo ""
+            echo "The script will install the latest containerd.io,"
+            echo "but containers may not run properly in LXC/Proxmox."
+            echo ""
+            CONTAINERD_FULL=""
+          else
+            echo "Found containerd version: $CONTAINERD_FULL"
+          fi
+        fi
+        
+        if [ -n "$CONTAINERD_FULL" ]; then
+          containerd_spec="containerd.io=${CONTAINERD_FULL}"
+        fi
+        echo ""
+      fi
+      
+      # Install Docker with appropriate containerd version
+      echo "Installing Docker CE (latest version)..."
+      echo "  docker-ce (latest)"
+      echo "  docker-ce-cli (latest)"
+      echo "  ${containerd_spec}"
+      echo "  docker-buildx-plugin (latest)"
+      echo "  docker-compose-plugin (latest)"
+      echo ""
+      
+      if ! $SUDO apt-get install -y \
+        docker-ce \
+        docker-ce-cli \
+        ${containerd_spec} \
+        docker-buildx-plugin \
+        docker-compose-plugin; then
+        echo ""
+        echo "ERROR: Docker installation failed!"
+        echo "Please check your internet connection and try again."
+        exit 1
+      fi
+      
+      echo "✓ Docker installed successfully"
+      echo ""
+      
+      # Hold containerd if we specified a version (LXC environment)
+      if [[ "$containerd_spec" == *"="* ]]; then
+        echo "Holding containerd.io at version ${CONTAINERD_VERSION}..."
+        $SUDO apt-mark hold containerd.io
+        echo ""
+      fi
+      
+      # Enable and start Docker
+      echo "Enabling and starting Docker service..."
+      $SUDO systemctl enable docker
+      $SUDO systemctl start docker
+      sleep 3
+      echo ""
+      
+      # Verify Docker is running
+      if ! $SUDO systemctl is-active --quiet docker; then
+        echo "ERROR: Docker service failed to start after installation"
+        echo "Check logs with: sudo journalctl -u docker -n 50"
+        exit 1
+      fi
+      
+      echo "✓ Docker service is running"
+      echo ""
+    else
+      echo "Docker is already installed"
+      echo ""
+      
+      # Check containerd version if in LXC environment
+      if check_lxc_environment; then
+        echo "Checking containerd.io version for LXC/Proxmox compatibility..."
+        local current_containerd=$(check_containerd_version)
+        echo "Current containerd.io version: $current_containerd"
+        echo ""
+        
+        # Check if we need to downgrade containerd
+        if [[ "$current_containerd" =~ 1\.7\.(28-2|29) ]] || [[ "$current_containerd" =~ 1\.7\.(3[0-9]) ]] || [[ "$current_containerd" =~ 1\.7\.[4-9][0-9] ]] || [[ "$current_containerd" =~ 1\.[8-9]\. ]] || [[ "$current_containerd" =~ ^2\. ]]; then
+          echo ""
+          echo "=========================================="
+          echo "CRITICAL: Problematic containerd.io Detected"
+          echo "=========================================="
+          echo ""
+          echo "Your containerd.io version ($current_containerd) is known to cause"
+          echo "'permission denied' errors in LXC/Proxmox containers."
+          echo ""
+          echo "This is due to CVE-2025-52881 AppArmor security patches."
+          echo "See: https://github.com/opencontainers/runc/issues/4968"
+          echo ""
+          echo "Downgrading to containerd.io ${CONTAINERD_VERSION}..."
+          echo ""
+          
+          # Resolve exact containerd version
+          CONTAINERD_FULL="${CONTAINERD_VERSION}~${OS}~${VERSION_CODENAME}"
+          
+          # Verify containerd version exists
+          if ! apt-cache madison containerd.io 2>/dev/null | grep -q "${CONTAINERD_FULL}"; then
+            echo "Exact containerd version ${CONTAINERD_FULL} not found"
+            echo "Searching for any 1.7.28-1 variant..."
+            CONTAINERD_FULL=$(apt-cache madison containerd.io 2>/dev/null | \
+              grep -E '1\.7\.28-1~' | \
+              head -n1 | \
+              awk '{print $3}')
+            
+            if [ -z "$CONTAINERD_FULL" ]; then
+              echo "ERROR: Could not find containerd.io 1.7.28-1 in repository"
+              echo "Available containerd.io versions:"
+              apt-cache madison containerd.io 2>/dev/null | head -n 5
+              echo ""
+              echo "⚠ WARNING: Cannot fix containerd version"
+              echo "Containers may not run properly in LXC/Proxmox."
+              echo ""
+            else
+              echo "Found containerd version: $CONTAINERD_FULL"
+              echo ""
+              
+              # Stop Docker services
+              echo "Stopping Docker services..."
+              $SUDO systemctl stop docker 2>/dev/null || true
+              $SUDO systemctl stop containerd 2>/dev/null || true
+              sleep 2
+              echo ""
+              
+              # Downgrade containerd
+              echo "Installing containerd.io=${CONTAINERD_FULL}..."
+              if $SUDO apt-get install -y --allow-downgrades containerd.io=${CONTAINERD_FULL}; then
+                echo "✓ Successfully downgraded containerd.io"
+                echo ""
+                
+                # Hold the package
+                echo "Holding containerd.io at version ${CONTAINERD_VERSION}..."
+                $SUDO apt-mark hold containerd.io
+                echo ""
+                
+                # Restart services
+                echo "Restarting Docker services..."
+                $SUDO systemctl start containerd 2>/dev/null || true
+                sleep 2
+                $SUDO systemctl start docker
+                sleep 3
+                echo ""
+                
+                if $SUDO systemctl is-active --quiet docker; then
+                  echo "✓ Docker service restarted successfully"
+                  echo ""
+                else
+                  echo "⚠ WARNING: Docker service failed to start after containerd downgrade"
+                  echo "Check logs with: sudo journalctl -u docker -n 50"
+                  echo ""
+                fi
+              else
+                echo "ERROR: Failed to downgrade containerd.io"
+                echo ""
+              fi
+            fi
+          else
+            echo "Found containerd version: $CONTAINERD_FULL"
+            echo ""
+            
+            # Stop Docker services
+            echo "Stopping Docker services..."
+            $SUDO systemctl stop docker 2>/dev/null || true
+            $SUDO systemctl stop containerd 2>/dev/null || true
+            sleep 2
+            echo ""
+            
+            # Downgrade containerd
+            echo "Installing containerd.io=${CONTAINERD_FULL}..."
+            if $SUDO apt-get install -y --allow-downgrades containerd.io=${CONTAINERD_FULL}; then
+              echo "✓ Successfully downgraded containerd.io"
+              echo ""
+              
+              # Hold the package
+              echo "Holding containerd.io at version ${CONTAINERD_VERSION}..."
+              $SUDO apt-mark hold containerd.io
+              echo ""
+              
+              # Restart services
+              echo "Restarting Docker services..."
+              $SUDO systemctl start containerd 2>/dev/null || true
+              sleep 2
+              $SUDO systemctl start docker
+              sleep 3
+              echo ""
+              
+              if $SUDO systemctl is-active --quiet docker; then
+                echo "✓ Docker service restarted successfully"
+                echo ""
+              else
+                echo "⚠ WARNING: Docker service failed to start after containerd downgrade"
+                echo "Check logs with: sudo journalctl -u docker -n 50"
+                echo ""
+              fi
+            else
+              echo "ERROR: Failed to downgrade containerd.io"
+              echo ""
+            fi
+          fi
+        else
+          echo "✓ containerd.io version is compatible (no downgrade needed)"
+          echo ""
+        fi
+      fi
+    fi
+    
+    # Now apply the override configuration
+    if apply_docker_api_override; then
+      echo ""
+      echo "=========================================="
+      echo "Docker API Override Applied Successfully!"
+      echo "=========================================="
+      echo ""
+      echo "Your system is now configured to work with CasaOS using newer Docker versions."
+      echo ""
+      
+      # Add user to docker group
+      add_user_to_docker_group
+      
+      # Restart CasaOS if installed
+      if check_casaos; then
+        echo "Restarting CasaOS services..."
+        stop_casaos_services
+        sleep 2
+        start_casaos_services
+      fi
+      
+      echo "Setup complete! CasaOS should now work properly with Docker."
+      echo ""
+      exit 0
+    else
+      echo ""
+      echo "ERROR: Failed to apply Docker API override"
+      echo "Please check the error messages above."
+      exit 1
+    fi
+  fi
   
   echo "Step 1b: Checking for Snap Docker installation..."
   if ! check_and_remove_snap_docker; then


### PR DESCRIPTION
Introduces functions to apply and remove a Docker API override using DOCKER_MIN_API_VERSION=1.24 for distributions where Docker 24.0.x is unavailable (e.g., Ubuntu 24.04+, Debian trixie). Updates messaging and main logic to support this alternative fix, allowing CasaOS to work with newer Docker versions without requiring a downgrade.