### PR TITLE
Fix install casaos

### DIFF
--- a/install-casaos/run.sh
+++ b/install-casaos/run.sh
@@ -32,7 +32,7 @@ NC='\033[0m' # No Color
 
 # Display Welcome
 echo -e "${BLUE}========================================${NC}"
-echo -e "${GREEN}BigBear CasaOS Installer V0.4${NC}"
+echo -e "${GREEN}BigBear CasaOS Installer V1.0.0${NC}"
 echo -e "${BLUE}========================================${NC}"
 echo "Here are some links:"
 echo "https://community.bigbeartechworld.com"


### PR DESCRIPTION
This pull request updates the CasaOS installer script to improve compatibility with recent Docker and containerd changes, particularly for LXC/Proxmox environments, and provides better version management and user messaging. The main improvements include new environment checks, compatibility fixes, and updated version references.

**Compatibility and environment checks:**

* Added `Check_LXC_Environment` and `Check_Containerd_LXC_Fix` functions to detect LXC/Proxmox containers and automatically downgrade `containerd.io` to version `1.7.28-1` if a problematic version is detected, addressing AppArmor issues and CVE-2025-52881.
* Inserted `Check_Docker_API_Compatibility` to detect Docker API version 1.52+ (Docker 29.x) and apply a systemd override for backward compatibility with CasaOS. [[1]](diffhunk://#diff-60abc4e672c5050f47cf46ca7e1cbfc8cac6a0598598bb27a8d48ce0027f632aR555-R717) [[2]](diffhunk://#diff-60abc4e672c5050f47cf46ca7e1cbfc8cac6a0598598bb27a8d48ce0027f632aR1172-R1176)

**Version management and messaging:**

* Updated installer version message from "V0.4" to "V1.0.0" for clarity and accuracy.
* Added a new readonly variable `CONTAINERD_VERSION="1.7.28-1"` for consistent reference throughout the script.
* Integrated new compatibility checks into the main installation flow, ensuring Docker and containerd are validated and fixed before proceeding.