### PR TITLE
Fix gpg download

### DIFF
--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -800,7 +800,8 @@ setup_docker_repository() {
   
   # Use timeout to prevent hanging on slow/broken mirrors
   echo "Updating package lists (timeout: 300s)..."
-  if ! timeout 300 $SUDO apt-get update 2>&1 | grep -v "^Get:\|^Hit:\|^Ign:" || [ ${PIPESTATUS[0]} -eq 124 ]; then
+  timeout 300 $SUDO apt-get update 2>&1 | grep -v "^Get:\|^Hit:\|^Ign:"
+  if [ ${PIPESTATUS[0]} -ne 0 ]; then
     echo "WARNING: apt-get update timed out or had issues"
     echo "Trying one more time..."
     if ! timeout 300 $SUDO apt-get update; then
@@ -871,7 +872,8 @@ setup_docker_repository() {
 
   # Update package index with new repository (force refresh)
   echo "Updating package lists with Docker repository (timeout: 300s)..."
-  if ! timeout 300 $SUDO apt-get update 2>&1 | grep -v "^Get:\|^Hit:\|^Ign:" || [ ${PIPESTATUS[0]} -eq 124 ]; then
+  timeout 300 $SUDO apt-get update 2>&1 | grep -v "^Get:\|^Hit:\|^Ign:"
+  if [ ${PIPESTATUS[0]} -ne 0 ]; then
     echo "ERROR: Failed to update package lists with Docker repository"
     echo "This operation timed out or failed. Common causes:"
     echo "  - Slow network connection"

--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -20,7 +20,7 @@ else
 fi
 
 echo "=========================================="
-echo "BigBear CasaOS Docker Version Fix Script 1.6.3"
+echo "BigBear CasaOS Docker Version Fix Script 1.6.2"
 echo "=========================================="
 echo ""
 echo "Here are some links:"
@@ -1419,7 +1419,7 @@ main() {
     case "$1" in
       apply-override|override)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 1.6.3"
+        echo "BigBear CasaOS Docker Version Fix Script 1.6.2"
         echo "=========================================="
         echo ""
         apply_docker_api_override
@@ -1427,7 +1427,7 @@ main() {
         ;;
       remove-override|no-override)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 1.6.3"
+        echo "BigBear CasaOS Docker Version Fix Script 1.6.2"
         echo "=========================================="
         echo ""
         remove_docker_api_override
@@ -1435,7 +1435,7 @@ main() {
         ;;
       help|--help|-h)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 1.6.3"
+        echo "BigBear CasaOS Docker Version Fix Script 1.6.2"
         echo "=========================================="
         echo ""
         show_usage


### PR DESCRIPTION
This pull request updates the `casaos-fix-docker-api-version/run.sh` script to improve reliability and user experience during Docker installation and version management. The main focus is on adding network connectivity checks, timeout mechanisms, retry logic, and clearer error messages to handle common issues such as slow networks, repository problems, or connectivity failures.

**Reliability and Error Handling Improvements:**

* Added timeout and retry logic to `apt-get update` and package installation steps to prevent hangs on slow or broken mirrors, with user-friendly warnings and suggestions for alternatives. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL801-R821) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL835-R884) [[3]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaR1093-R1113)
* Implemented retry and fallback mechanisms for downloading Docker's GPG key, including switching to HTTP/1.1 if standard download fails, and improved messaging for failures.

**User Experience Enhancements:**

* Added a network connectivity check before starting the installation process, with an option for the user to cancel if the Docker repository is unreachable.
* Improved progress and error messages throughout the script, including installation status, timeouts, and log file locations for troubleshooting. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaR1093-R1113) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaR1122-R1124)

**Versioning and Messaging Updates:**

* Updated script version from `1.6.1` to `1.6.2` in all relevant output messages. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL23-R23) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1360-R1438)

**Step Renumbering for Clarity:**

* Renumbered installation steps to reflect new checks, ensuring the process flow is clear and easy to follow. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1681-R1769) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1694-R1782)