### PR TITLE
Add more timeouts

### DIFF
--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -90,7 +90,7 @@ display_versions() {
     
     # Also show installed package versions for clarity
     echo "Installed Docker packages:"
-    dpkg -l | grep -E "docker-ce|containerd.io" | awk '{print $2, $3}' 2>/dev/null || echo "Unable to query package versions"
+    timeout 10 dpkg -l 2>/dev/null | grep -E "docker-ce|containerd.io" | awk '{print $2, $3}' || echo "Unable to query package versions"
     echo ""
   else
     echo "Docker command not found"
@@ -317,8 +317,8 @@ check_containerd_version() {
     return 1
   fi
   
-  # Get installed version
-  local version=$(dpkg -l | grep containerd.io | awk '{print $3}' | head -n1)
+  # Get installed version (use timeout to prevent hanging if dpkg is locked)
+  local version=$(timeout 10 dpkg -l 2>/dev/null | grep containerd.io | awk '{print $3}' | head -n1)
   echo "$version"
   return 0
 }
@@ -961,8 +961,8 @@ remove_standalone_docker_compose() {
   if command -v docker-compose &>/dev/null; then
     echo "Standalone docker-compose found. Checking installation method..."
 
-    # Check if docker-compose was installed via package manager
-    if dpkg -l | grep -qw docker-compose 2>/dev/null; then
+    # Check if docker-compose was installed via package manager (use timeout to prevent hang)
+    if timeout 10 dpkg -l 2>/dev/null | grep -qw docker-compose; then
       echo "Removing docker-compose installed via package manager..."
       $SUDO apt-get remove -y docker-compose
     else
@@ -1085,7 +1085,7 @@ downgrade_docker() {
   echo ""
 
   # Check if Docker is already installed and remove it to ensure clean downgrade
-  if dpkg -l | grep -qE "docker-ce|containerd.io"; then
+  if timeout 10 dpkg -l 2>/dev/null | grep -qE "docker-ce|containerd.io"; then
     echo "Removing existing Docker packages to ensure clean installation..."
     
     # Stop Docker services before removal
@@ -2021,7 +2021,7 @@ main() {
   echo "=========================================="
   echo ""
   echo "Installed Docker Package Versions:"
-  dpkg -l | grep -E "docker-ce|containerd.io" | awk '{print "  " $2 " = " $3}' 2>/dev/null || echo "Unable to query package versions"
+  timeout 10 dpkg -l 2>/dev/null | grep -E "docker-ce|containerd.io" | awk '{print "  " $2 " = " $3}' || echo "Unable to query package versions"
   echo ""
   echo "Docker Version Information:"
   timeout 10 $SUDO docker version 2>&1 || echo "Unable to get Docker version"
@@ -2077,7 +2077,7 @@ main() {
     
     # Check installed packages
     echo "4. Installed Docker packages:"
-    dpkg -l | grep -E "docker-ce|containerd.io" | awk '{print "   " $2 " = " $3}' 2>/dev/null || echo "   Unable to query packages"
+    timeout 10 dpkg -l 2>/dev/null | grep -E "docker-ce|containerd.io" | awk '{print "   " $2 " = " $3}' || echo "   Unable to query packages"
     echo ""
     
     # Check Docker service status

--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -318,7 +318,8 @@ check_containerd_version() {
   fi
   
   # Get installed version (use timeout to prevent hanging if dpkg is locked)
-  local version=$(timeout 10 dpkg -l 2>/dev/null | grep containerd.io | awk '{print $3}' | head -n1)
+  local version
+  version=$(timeout 10 dpkg -l 2>/dev/null | grep containerd.io | awk '{print $3}' | head -n1)
   echo "$version"
   return 0
 }

--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -59,7 +59,7 @@ print_info() {
 }
 
 echo "=========================================="
-echo "BigBear CasaOS Docker Version Fix Script 2025.11.0"
+echo "BigBear CasaOS Docker Version Fix Script 2025.11.1"
 echo "=========================================="
 echo ""
 echo "Here are some links:"
@@ -1572,7 +1572,7 @@ main() {
     case "$1" in
       apply-override|override)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 2025.11.0"
+        echo "BigBear CasaOS Docker Version Fix Script 2025.11.1"
         echo "=========================================="
         echo ""
         apply_docker_api_override
@@ -1580,7 +1580,7 @@ main() {
         ;;
       remove-override|no-override)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 2025.11.0"
+        echo "BigBear CasaOS Docker Version Fix Script 2025.11.1"
         echo "=========================================="
         echo ""
         remove_docker_api_override
@@ -1588,7 +1588,7 @@ main() {
         ;;
       help|--help|-h)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 2025.11.0"
+        echo "BigBear CasaOS Docker Version Fix Script 2025.11.1"
         echo "=========================================="
         echo ""
         show_usage

--- a/casaos-fix-docker-api-version/test-script.sh
+++ b/casaos-fix-docker-api-version/test-script.sh
@@ -1621,10 +1621,13 @@ EOF
   print_info "Testing: timeout 10 dpkg -l"
   
   # Test the timeout command directly
-  local start_time=$(date +%s)
+  local start_time
+  start_time=$(date +%s)
   timeout 10 dpkg -l >/dev/null 2>&1
-  local exit_code=$?
-  local end_time=$(date +%s)
+  local exit_code
+  exit_code=$?
+  local end_time
+  end_time=$(date +%s)
   local duration=$((end_time - start_time))
   
   # Restore PATH

--- a/casaos-fix-docker-api-version/test-script.sh
+++ b/casaos-fix-docker-api-version/test-script.sh
@@ -1663,7 +1663,7 @@ EOF
   print_info "Testing actual display_versions function..."
   
   # Extract just the function from run.sh - but use explicit mock path
-  local test_script="/tmp/test-dpkg-func-$$.sh"
+  test_script="/tmp/test-dpkg-func-$$.sh"
   cat > "$test_script" << TESTEOF
 #!/bin/bash
 set -o pipefail


### PR DESCRIPTION
This pull request improves the reliability of the CasaOS Docker Version Fix scripts by adding robust handling for potential hangs in `dpkg -l` commands, which can occur if the package database is locked. The changes ensure that any calls to `dpkg -l` are wrapped with a timeout, preventing the scripts from hanging indefinitely. Additionally, the test suite is enhanced to verify this behavior with a dedicated test for `dpkg` hangs.

**Robust handling for dpkg hangs:**

* All instances of `dpkg -l` in `run.sh` are now wrapped with `timeout 10` to prevent the script from hanging if the package database is locked. This applies to displaying Docker package versions, checking installed packages, and removing Docker-related packages. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL93-R93) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL320-R321) [[3]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL964-R965) [[4]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1088-R1088) [[5]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL2024-R2024) [[6]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL2080-R2080)

**Test suite enhancements:**

* A new test, `test_dpkg_hang`, is added to `test-script.sh` to simulate and verify handling of a hanging `dpkg -l` command using a mock dpkg binary and timeout logic.
* The usage instructions and bug fix test summary are updated to include the new `test-dpkg` command and results. [[1]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR1294) [[2]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR1320) [[3]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR1744-R1751) [[4]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1627-R1767) [[5]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1643-R1783) [[6]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1659-R1799) [[7]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1675-R1815) [[8]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1691-R1831) [[9]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR1840-R1855) [[10]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR1920-R1922)

**Other improvements:**

* The script version string is updated from `2025.11.0` to `2025.11.1` in all relevant output locations for clarity. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL62-R62) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaL1575-R1591)

These changes make the CasaOS Docker Version Fix scripts more robust and easier to test, especially in environments where package database locks are common.