### PR TITLE
Add allowlist support with ranges and comments

### DIFF
--- a/.github/workflows/test-unicode-scanner.yml
+++ b/.github/workflows/test-unicode-scanner.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Test scanning a clean file
         working-directory: check-for-unicode
         run: |
-          ./run.sh test-suite/clean-test.js
-          if [ $? -eq 0 ]; then
+          if ./run.sh test-suite/clean-test.js; then
             echo "✓ Clean file test passed"
           else
             echo "✗ Clean file test failed"

--- a/.github/workflows/test-unicode-scanner.yml
+++ b/.github/workflows/test-unicode-scanner.yml
@@ -1,0 +1,91 @@
+name: Test Unicode Security Scanner
+
+on:
+  push:
+    paths:
+      - 'check-for-unicode/**'
+  pull_request:
+    paths:
+      - 'check-for-unicode/**'
+  workflow_dispatch:
+
+jobs:
+  test-scanner:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: |
+          chmod +x check-for-unicode/run.sh
+          chmod +x check-for-unicode/test-suite/run-tests.sh
+
+      - name: Display scanner version
+        working-directory: check-for-unicode
+        run: ./run.sh --version
+
+      - name: Run test suite
+        working-directory: check-for-unicode/test-suite
+        run: bash run-tests.sh
+
+      - name: Test scanner help
+        working-directory: check-for-unicode
+        run: ./run.sh --help
+
+      - name: Test scanning a clean file
+        working-directory: check-for-unicode
+        run: |
+          ./run.sh test-suite/clean-test.js
+          if [ $? -eq 0 ]; then
+            echo "✓ Clean file test passed"
+          else
+            echo "✗ Clean file test failed"
+            exit 1
+          fi
+
+      - name: Test detection of malicious file
+        working-directory: check-for-unicode
+        run: |
+          ./run.sh test-suite/trojan-source-test.js && exit 1 || true
+          echo "✓ Malicious file correctly detected"
+
+      - name: Test JSON output
+        working-directory: check-for-unicode
+        run: |
+          output=$(./run.sh --json test-suite/clean-test.js)
+          echo "$output" | jq .
+          if echo "$output" | jq -e '.scanner' > /dev/null; then
+            echo "✓ JSON output test passed"
+          else
+            echo "✗ JSON output test failed"
+            exit 1
+          fi
+
+      - name: Test quiet mode
+        working-directory: check-for-unicode
+        run: |
+          output=$(./run.sh --quiet test-suite/clean-test.js 2>&1)
+          if [ -z "$output" ]; then
+            echo "✓ Quiet mode test passed (no output)"
+          else
+            echo "✗ Quiet mode test failed (unexpected output: $output)"
+            exit 1
+          fi
+
+  test-scanner-macos:
+    runs-on: macos-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Make scripts executable
+        run: |
+          chmod +x check-for-unicode/run.sh
+          chmod +x check-for-unicode/test-suite/run-tests.sh
+
+      - name: Run test suite on macOS
+        working-directory: check-for-unicode/test-suite
+        run: bash run-tests.sh

--- a/.github/workflows/test-unicode-scanner.yml
+++ b/.github/workflows/test-unicode-scanner.yml
@@ -11,8 +11,15 @@ on:
 
 jobs:
   test-scanner:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     
+    defaults:
+      run:
+        shell: bash
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -32,7 +39,20 @@ jobs:
 
       - name: Test scanner help
         working-directory: check-for-unicode
-        run: ./run.sh --help
+        run: |
+          output=$(./run.sh --help)
+          if echo "$output" | grep -q "ALLOWLIST FORMAT"; then
+            echo "✓ Help includes allowlist documentation"
+          else
+            echo "✗ Help missing allowlist documentation"
+            exit 1
+          fi
+          if echo "$output" | grep -q "exclude-emojis"; then
+            echo "✓ Help includes emoji exclusion flag"
+          else
+            echo "✗ Help missing emoji exclusion flag"
+            exit 1
+          fi
 
       - name: Test scanning a clean file
         working-directory: check-for-unicode
@@ -47,8 +67,12 @@ jobs:
       - name: Test detection of malicious file
         working-directory: check-for-unicode
         run: |
-          ./run.sh test-suite/trojan-source-test.js && exit 1 || true
-          echo "✓ Malicious file correctly detected"
+          if ./run.sh test-suite/trojan-source-test.js; then
+            echo "✗ Malicious file was not detected"
+            exit 1
+          else
+            echo "✓ Malicious file correctly detected"
+          fi
 
       - name: Test JSON output
         working-directory: check-for-unicode
@@ -72,19 +96,3 @@ jobs:
             echo "✗ Quiet mode test failed (unexpected output: $output)"
             exit 1
           fi
-
-  test-scanner-macos:
-    runs-on: macos-latest
-    
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Make scripts executable
-        run: |
-          chmod +x check-for-unicode/run.sh
-          chmod +x check-for-unicode/test-suite/run-tests.sh
-
-      - name: Run test suite on macOS
-        working-directory: check-for-unicode/test-suite
-        run: bash run-tests.sh

--- a/check-for-unicode/test-suite/.unicode-allowlist-test
+++ b/check-for-unicode/test-suite/.unicode-allowlist-test
@@ -1,9 +1,15 @@
 # Test allowlist for Unicode Security Scanner
 # Format: One Unicode code per line (with or without U+ prefix)
-# Comments start with #
+# Supports: inline comments, ranges (U+XXXX-U+YYYY)
+#
+# Examples:
+#   U+200B           - Single code with prefix
+#   200B             - Single code without prefix  
+#   U+200B # comment - Code with inline description
+#   U+0400-U+04FF    - Range of codes (entire Cyrillic block)
 
 # Allow zero-width space for this test
-U+200B
+U+200B  # Zero Width Space - needed for legitimate i18n word boundaries
 
 # Allow some homograph characters for legitimate internationalization
-U+0430
+U+0430  # Cyrillic Small Letter A - for Russian language support


### PR DESCRIPTION
This pull request introduces major improvements to the Unicode Security Scanner, focusing on enhanced allowlist functionality and expanded test coverage. The scanner now supports allowlisting individual Unicode codes, code ranges, and inline comments, making it more flexible for legitimate internationalization use cases. Comprehensive tests have been added to verify these new features, and the documentation and workflow have been updated accordingly.

**Allowlist Functionality Enhancements:**

* Added support for allowlisting Unicode code points using single codes, code ranges (e.g., `U+0400-U+04FF`), and inline comments in the allowlist file. The scanner now parses these formats, validates entries, and ignores allowlisted codes or ranges during scanning. (`check-for-unicode/run.sh`, `check-for-unicode/test-suite/.unicode-allowlist-test`) [[1]](diffhunk://#diff-450daa7f5ed9a8be03d016377da69660c24e86cc1cacc660ecac3a89919502adR20-R23) [[2]](diffhunk://#diff-450daa7f5ed9a8be03d016377da69660c24e86cc1cacc660ecac3a89919502adL84-R174) [[3]](diffhunk://#diff-3a1916ef7f697b29dd27e0df746da50f3987073d2ef1eb387cdef8c2341fa13fL3-R15)
* Improved documentation in the scanner help output to describe the new allowlist formats and usage examples. (`check-for-unicode/run.sh`) [[1]](diffhunk://#diff-450daa7f5ed9a8be03d016377da69660c24e86cc1cacc660ecac3a89919502adR60-R66) [[2]](diffhunk://#diff-450daa7f5ed9a8be03d016377da69660c24e86cc1cacc660ecac3a89919502adR75)

**Test Suite Improvements:**

* Expanded the test suite to cover allowlist functionality, including tests for single-code allowlisting, range allowlisting, and inline comments. The tests verify that allowlisted characters are ignored and that dangerous Unicode is still detected when not allowlisted. (`check-for-unicode/test-suite/run-tests.sh`)
* Updated the allowlist test file to demonstrate new formats and comments. (`check-for-unicode/test-suite/.unicode-allowlist-test`)

**Workflow Updates:**

* Added a dedicated GitHub Actions workflow for testing the Unicode Security Scanner, including steps for running the test suite and verifying scanner behavior on both Ubuntu and macOS. (`.github/workflows/test-unicode-scanner.yml`)

**Minor Fixes:**

* Corrected a typo in the harmful Unicode patterns list for the scanner. (`check-for-unicode/run.sh`)
* Updated the scanner version to `2025.11.0` in the script header and version output. (`check-for-unicode/run.sh`)

These changes make the scanner much more adaptable for real-world usage where certain Unicode characters may be required, while ensuring robust security scanning and clear documentation.