### PR TITLE
Implement active polling for Docker startup readiness

### DIFF
--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -59,7 +59,7 @@ print_info() {
 }
 
 echo "=========================================="
-echo "BigBear CasaOS Docker Version Fix Script 2025.11.1"
+echo "BigBear CasaOS Docker Version Fix Script 2025.12.0"
 echo "=========================================="
 echo ""
 echo "Here are some links:"
@@ -1638,7 +1638,7 @@ main() {
     case "$1" in
       apply-override|override)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 2025.11.1"
+        echo "BigBear CasaOS Docker Version Fix Script 2025.12.0"
         echo "=========================================="
         echo ""
         apply_docker_api_override
@@ -1646,7 +1646,7 @@ main() {
         ;;
       remove-override|no-override)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 2025.11.1"
+        echo "BigBear CasaOS Docker Version Fix Script 2025.12.0"
         echo "=========================================="
         echo ""
         remove_docker_api_override
@@ -1654,7 +1654,7 @@ main() {
         ;;
       help|--help|-h)
         echo "=========================================="
-        echo "BigBear CasaOS Docker Version Fix Script 2025.11.1"
+        echo "BigBear CasaOS Docker Version Fix Script 2025.12.0"
         echo "=========================================="
         echo ""
         show_usage

--- a/casaos-fix-docker-api-version/run.sh
+++ b/casaos-fix-docker-api-version/run.sh
@@ -595,16 +595,30 @@ EOF
   # Reload systemd daemon
   echo "Reloading systemd daemon..."
   $SUDO systemctl daemon-reload
+  sleep 2
   echo ""
   
   # Restart Docker
   echo "Restarting Docker service..."
   timeout 30 $SUDO systemctl restart docker
-  sleep 3
+  
+  # Wait for Docker to be fully ready with active polling
+  echo "Waiting for Docker to be fully ready..."
+  local docker_ready=false
+  for i in {1..10}; do
+    if $SUDO systemctl is-active --quiet docker 2>/dev/null; then
+      if timeout 5 $SUDO docker info >/dev/null 2>&1; then
+        docker_ready=true
+        break
+      fi
+    fi
+    echo "  Waiting for Docker... ($i/10)"
+    sleep 2
+  done
   echo ""
   
   # Verify Docker is running
-  if $SUDO systemctl is-active --quiet docker; then
+  if [ "$docker_ready" = true ] || $SUDO systemctl is-active --quiet docker; then
     echo "✓ Docker service restarted successfully"
     
     # Show current Docker info
@@ -651,15 +665,29 @@ remove_docker_api_override() {
   # Reload systemd daemon
   echo "Reloading systemd daemon..."
   $SUDO systemctl daemon-reload
+  sleep 2
   echo ""
   
   # Restart Docker
   echo "Restarting Docker service..."
   timeout 30 $SUDO systemctl restart docker
-  sleep 3
+  
+  # Wait for Docker to be fully ready with active polling
+  echo "Waiting for Docker to be fully ready..."
+  local docker_ready=false
+  for i in {1..10}; do
+    if $SUDO systemctl is-active --quiet docker 2>/dev/null; then
+      if timeout 5 $SUDO docker info >/dev/null 2>&1; then
+        docker_ready=true
+        break
+      fi
+    fi
+    echo "  Waiting for Docker... ($i/10)"
+    sleep 2
+  done
   echo ""
   
-  if $SUDO systemctl is-active --quiet docker; then
+  if [ "$docker_ready" = true ] || $SUDO systemctl is-active --quiet docker; then
     echo "✓ Docker API override removed successfully"
     echo ""
     return 0
@@ -1230,13 +1258,15 @@ downgrade_docker() {
   # Reload systemd and restart Docker service
   echo "Reloading systemd daemon..."
   $SUDO systemctl daemon-reload
+  # Wait for systemd to fully process the reload
+  sleep 2
   echo ""
 
   # Ensure Docker is completely stopped before starting
   echo "Step 7.2: Ensuring Docker is completely stopped..."
   timeout 30 $SUDO systemctl stop docker.socket 2>/dev/null || true
   timeout 30 $SUDO systemctl stop docker 2>/dev/null || true
-  sleep 2
+  sleep 3
   
   # Use the new function to ensure processes are stopped
   ensure_docker_processes_stopped
@@ -1244,26 +1274,61 @@ downgrade_docker() {
   # Stop containerd to ensure clean slate
   echo "Restarting containerd for clean state..."
   timeout 30 $SUDO systemctl stop containerd 2>/dev/null || true
-  sleep 1
+  sleep 2
   if pgrep -x containerd >/dev/null 2>&1; then
     $SUDO pkill -9 containerd 2>/dev/null || true
-    sleep 1
+    sleep 2
   fi
   $SUDO systemctl start containerd 2>/dev/null || true
-  sleep 2
+  
+  # Wait for containerd to be fully ready before starting Docker
+  echo "Waiting for containerd to be fully ready..."
+  local containerd_ready=false
+  for i in {1..10}; do
+    if $SUDO systemctl is-active --quiet containerd 2>/dev/null; then
+      containerd_ready=true
+      echo "✓ containerd is ready"
+      break
+    fi
+    echo "  Waiting for containerd... ($i/10)"
+    sleep 1
+  done
+  
+  if [ "$containerd_ready" = false ]; then
+    echo "⚠ WARNING: containerd may not be fully ready, proceeding anyway..."
+  fi
   echo ""
 
   # Enable and start docker socket first, then service
   echo "Step 7.3: Enabling and starting Docker socket..."
   $SUDO systemctl enable docker.socket 2>/dev/null || true
   $SUDO systemctl start docker.socket
-  sleep 1
+  sleep 2
   echo ""
 
   echo "Step 7.4: Enabling and starting Docker service..."
   $SUDO systemctl enable docker
   $SUDO systemctl start docker
-  sleep 5  # Give Docker more time to fully initialize
+  
+  # Wait for Docker to be fully ready with active polling instead of fixed sleep
+  echo "Waiting for Docker to be fully ready..."
+  local docker_ready=false
+  for i in {1..15}; do
+    if $SUDO systemctl is-active --quiet docker 2>/dev/null; then
+      # Double-check that Docker is actually responding
+      if timeout 5 $SUDO docker info >/dev/null 2>&1; then
+        docker_ready=true
+        echo "✓ Docker is ready and responding"
+        break
+      fi
+    fi
+    echo "  Waiting for Docker... ($i/15)"
+    sleep 2
+  done
+  
+  if [ "$docker_ready" = false ]; then
+    echo "⚠ Docker may not be fully ready after 30 seconds..."
+  fi
   echo ""
   
   # Verify Docker is running


### PR DESCRIPTION
This pull request improves the reliability of the Docker startup process in the `run.sh` script by replacing fixed sleep delays with active polling to ensure both Docker and containerd are fully ready before proceeding. It also updates the test suite in `test-script.sh` to verify this new polling logic and includes a dedicated test for the "two runs needed" bug. These changes address issues where previous fixed sleep times could result in race conditions, requiring multiple runs for successful initialization.

**Startup reliability improvements:**

* Replaced all fixed sleep delays after restarting Docker and containerd in `run.sh` with active polling loops that check service readiness. The script now waits for both `systemctl is-active` and a successful `docker info` response before continuing, improving robustness and eliminating the "two runs needed" bug. [[1]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaR598-R621) [[2]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaR668-R690) [[3]](diffhunk://#diff-198701c5a479170ce972c97f3fc3fffdb839d314cdf1e68849f24463f63756aaR1261-R1331)

**Testing and verification enhancements:**

* Added a new `test_docker_startup_polling` function to `test-script.sh` that verifies the polling logic is present in `run.sh`, simulates slow Docker startup, and checks that old fixed sleep patterns are removed. This test ensures the new logic works as intended.
* Updated usage instructions and command handling in `test-script.sh` to include the new polling test, making it easier for users to run and verify the fix. [[1]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR1295) [[2]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR1322) [[3]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR2172-R2174)

**Test suite updates:**

* Integrated the new Docker startup polling test into the comprehensive bug fix test suite, increasing the total number of tests and updating all related output and counters. [[1]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR1977-R1984) [[2]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1783-R2000) [[3]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1799-R2016) [[4]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1815-R2032) [[5]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1831-R2048) [[6]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1847-R2064) [[7]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cL1863-R2080) [[8]](diffhunk://#diff-798c31cd0b1cb37db663ef85870889fbf06abd5715e27d3ae885d6f637cee96cR2089-R2104)