### PR TITLE
🔤 Update Unicode scanner to v2026.03.0

### DIFF
--- a/check-for-unicode/run.sh
+++ b/check-for-unicode/run.sh
@@ -54,9 +54,9 @@ OPTIONS:
     --allowlist FILE    Path to allowlist file (default: .unicode-allowlist)
     --exclude-emojis    Exclude emoji characters and variation selectors (reduces false positives)
     --exclude-common    Exclude common Unicode typography: smart quotes, dashes,
-                        ellipsis, soft hyphen, superscripts, subscripts, Roman
-                        numerals (recommended for docs/markdown repos; note:
-                        also suppresses some AI-confusion and homograph checks)
+                        ellipsis, superscripts, subscripts, Roman numerals
+                        (recommended for docs/markdown repos; note: also
+                        suppresses some AI-confusion and homograph checks)
     --include-binary    Include binary files (archives, images, executables, etc.)
                         By default, only text files are scanned to avoid false positives
 
@@ -205,15 +205,15 @@ is_common_unicode() {
     [[ "$unicode_code" =~ ^203[9A]$ ]] && return 0
     # Per mille: U+2030
     [[ "$unicode_code" == "2030" ]] && return 0
-    # Soft Hyphen: U+00AD (invisible formatting hint, harmless in HTML/markdown)
-    [[ "$unicode_code" == "00AD" ]] && return 0
     # Superscript digits: U+00B2 (²), U+00B3 (³), U+00B9 (¹), U+2070-U+2079
     [[ "$unicode_code" =~ ^00B[239]$ ]] && return 0
     [[ "$unicode_code" =~ ^207[0-9]$ ]] && return 0
     # Subscript digits: U+2080-U+2084
     [[ "$unicode_code" =~ ^208[0-4]$ ]] && return 0
-    # Roman numerals: U+2160-U+217F (used in outlines, legal docs, lists)
-    [[ "$unicode_code" =~ ^21[67][0-9A-F]$ ]] && return 0
+    # Roman numerals: U+2160-U+217F, excluding Latin-lookalike confusables
+    # (U+2160 I, U+2165 VI, U+2169 X, U+2174 v, U+2179 x remain detectable)
+    [[ "$unicode_code" =~ ^21[67][0-9A-F]$ ]] && \
+        [[ ! "$unicode_code" =~ ^(2160|2165|2169|2174|2179)$ ]] && return 0
     return 1
 }
 

--- a/check-for-unicode/run.sh
+++ b/check-for-unicode/run.sh
@@ -54,7 +54,8 @@ OPTIONS:
     --allowlist FILE    Path to allowlist file (default: .unicode-allowlist)
     --exclude-emojis    Exclude emoji characters and variation selectors (reduces false positives)
     --exclude-common    Exclude common Unicode typography: smart quotes, dashes,
-                        ellipsis, superscripts, subscripts, Roman numerals
+                        ellipsis, common spaces, angle quotes, per mille,
+                        superscripts, subscripts, non-confusable Roman numerals
                         (recommended for docs/markdown repos; note: also
                         suppresses some AI-confusion and homograph checks)
     --include-binary    Include binary files (archives, images, executables, etc.)
@@ -206,6 +207,7 @@ is_common_unicode() {
     # Per mille: U+2030
     [[ "$unicode_code" == "2030" ]] && return 0
     # Superscript digits: U+00B2 (²), U+00B3 (³), U+00B9 (¹), U+2070-U+2079
+    # Note: ^207[0-9]$ also covers U+2071 (ⁱ) and U+2073 which are not in harmful_patterns
     [[ "$unicode_code" =~ ^00B[239]$ ]] && return 0
     [[ "$unicode_code" =~ ^207[0-9]$ ]] && return 0
     # Subscript digits: U+2080-U+2084

--- a/check-for-unicode/run.sh
+++ b/check-for-unicode/run.sh
@@ -54,8 +54,9 @@ OPTIONS:
     --allowlist FILE    Path to allowlist file (default: .unicode-allowlist)
     --exclude-emojis    Exclude emoji characters and variation selectors (reduces false positives)
     --exclude-common    Exclude common Unicode typography: smart quotes, dashes,
-                        ellipsis, soft hyphen, superscripts, subscripts,
-                        Roman numerals (recommended for docs/markdown repos)
+                        ellipsis, soft hyphen, superscripts, subscripts, Roman
+                        numerals (recommended for docs/markdown repos; note:
+                        also suppresses some AI-confusion and homograph checks)
     --include-binary    Include binary files (archives, images, executables, etc.)
                         By default, only text files are scanned to avoid false positives
 
@@ -644,8 +645,8 @@ load_allowlist
 # Show header unless in quiet or JSON mode
 if [ "$QUIET_MODE" = false ] && [ "$JSON_OUTPUT" = false ]; then
     echo -e "\033[1;35m╔══════════════════════════════════════════════════════════════╗\033[0m"
-    echo -e "\033[1;35m║     Big Bear Unicode Security Scanner v${VERSION} AI+     ║\033[0m"
-    echo -e "\033[1;35m║       Detecting dangerous Unicode & AI injection attacks      ║\033[0m"
+    echo -e "\033[1;35m║       Big Bear Unicode Security Scanner v${VERSION} AI+       ║\033[0m"
+    echo -e "\033[1;35m║       Detecting dangerous Unicode & AI injection attacks     ║\033[0m"
     echo -e "\033[1;35m║                       Please support me!                     ║\033[0m"
     echo -e "\033[1;35m║               https://ko-fi.com/bigbeartechworld             ║\033[0m"
     echo -e "\033[1;35m║                           Thank you!                         ║\033[0m"

--- a/check-for-unicode/run.sh
+++ b/check-for-unicode/run.sh
@@ -211,12 +211,8 @@ is_common_unicode() {
     [[ "$unicode_code" =~ ^207[0-9]$ ]] && return 0
     # Subscript digits: U+2080-U+2084
     [[ "$unicode_code" =~ ^208[0-4]$ ]] && return 0
-    # Roman numerals: U+2160-U+2179 (used in outlines, legal docs, lists)
+    # Roman numerals: U+2160-U+217F (used in outlines, legal docs, lists)
     [[ "$unicode_code" =~ ^21[67][0-9A-F]$ ]] && return 0
-    # Combining diacritical marks (U+0300-U+030C) — used in accented Latin text (French, Spanish, etc.)
-    [[ "$unicode_code" =~ ^030[0-9A-C]$ ]] && return 0
-    # Replacement Character U+FFFD — appears naturally from encoding tools/editors, not a security threat
-    [[ "$unicode_code" == "FFFD" ]] && return 0
     return 1
 }
 

--- a/check-for-unicode/run.sh
+++ b/check-for-unicode/run.sh
@@ -210,8 +210,8 @@ is_common_unicode() {
     # Note: ^207[0-9]$ also covers U+2071 (ⁱ) and U+2073 which are not in harmful_patterns
     [[ "$unicode_code" =~ ^00B[239]$ ]] && return 0
     [[ "$unicode_code" =~ ^207[0-9]$ ]] && return 0
-    # Subscript digits: U+2080-U+2084
-    [[ "$unicode_code" =~ ^208[0-4]$ ]] && return 0
+    # Subscript digits: U+2080-U+2089
+    [[ "$unicode_code" =~ ^208[0-9]$ ]] && return 0
     # Roman numerals: U+2160-U+217F, excluding Latin-lookalike confusables
     # (U+2160 I, U+2165 VI, U+2169 X, U+2174 v, U+2179 x remain detectable)
     [[ "$unicode_code" =~ ^21[67][0-9A-F]$ ]] && \

--- a/check-for-unicode/run.sh
+++ b/check-for-unicode/run.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-# Unicode Security Scanner v2025.11.0 AI+
+# Unicode Security Scanner v2026.03.0 AI+
 # Detects dangerous Unicode characters that can be used in security attacks
 # Including Trojan Source attacks (CVE-2021-42574) and other invisible characters
 
 # Script configuration
-VERSION="2025.11.0"
+VERSION="2026.03.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Command-line options (defaults)
@@ -53,7 +53,9 @@ OPTIONS:
                         (comma-separated, e.g., "critical,high")
     --allowlist FILE    Path to allowlist file (default: .unicode-allowlist)
     --exclude-emojis    Exclude emoji characters and variation selectors (reduces false positives)
-    --exclude-common    Exclude common Unicode like smart quotes, dashes (very permissive)
+    --exclude-common    Exclude common Unicode typography: smart quotes, dashes,
+                        ellipsis, superscripts, subscripts, Roman numerals,
+                        combining accents (recommended for docs/markdown repos)
     --include-binary    Include binary files (archives, images, executables, etc.)
                         By default, only text files are scanned to avoid false positives
 
@@ -202,6 +204,19 @@ is_common_unicode() {
     [[ "$unicode_code" =~ ^203[9A]$ ]] && return 0
     # Per mille: U+2030
     [[ "$unicode_code" == "2030" ]] && return 0
+    # Soft Hyphen: U+00AD (invisible formatting hint, harmless in HTML/markdown)
+    [[ "$unicode_code" == "00AD" ]] && return 0
+    # Superscript digits: U+00B2 (²), U+00B3 (³), U+00B9 (¹), U+2070-U+2079
+    [[ "$unicode_code" =~ ^00B[239]$ ]] && return 0
+    [[ "$unicode_code" =~ ^207[0-9]$ ]] && return 0
+    # Subscript digits: U+2080-U+2084
+    [[ "$unicode_code" =~ ^208[0-4]$ ]] && return 0
+    # Roman numerals: U+2160-U+2179 (used in outlines, legal docs, lists)
+    [[ "$unicode_code" =~ ^21[67][0-9A-F]$ ]] && return 0
+    # Combining diacritical marks (U+0300-U+030C) — used in accented Latin text (French, Spanish, etc.)
+    [[ "$unicode_code" =~ ^030[0-9A-C]$ ]] && return 0
+    # Replacement Character U+FFFD — appears naturally from encoding tools/editors, not a security threat
+    [[ "$unicode_code" == "FFFD" ]] && return 0
     return 1
 }
 

--- a/check-for-unicode/run.sh
+++ b/check-for-unicode/run.sh
@@ -54,8 +54,8 @@ OPTIONS:
     --allowlist FILE    Path to allowlist file (default: .unicode-allowlist)
     --exclude-emojis    Exclude emoji characters and variation selectors (reduces false positives)
     --exclude-common    Exclude common Unicode typography: smart quotes, dashes,
-                        ellipsis, superscripts, subscripts, Roman numerals,
-                        combining accents (recommended for docs/markdown repos)
+                        ellipsis, soft hyphen, superscripts, subscripts,
+                        Roman numerals (recommended for docs/markdown repos)
     --include-binary    Include binary files (archives, images, executables, etc.)
                         By default, only text files are scanned to avoid false positives
 
@@ -72,7 +72,7 @@ EXAMPLES:
     $0 --quiet --json ./app/ > results.json  # JSON output for CI
     $0 --severity critical,high ./        # Only show critical/high
     $0 --exclude-emojis ./ui/             # Skip emoji characters in UI code
-    $0 --exclude-common ./docs/           # Very permissive for documentation
+    $0 --exclude-common ./docs/           # Recommended for docs/markdown repos
     $0 --include-binary ./                # Scan all files including binaries
     $0 --allowlist .unicode-allowlist ./  # Use custom allowlist
 
@@ -644,7 +644,7 @@ load_allowlist
 # Show header unless in quiet or JSON mode
 if [ "$QUIET_MODE" = false ] && [ "$JSON_OUTPUT" = false ]; then
     echo -e "\033[1;35m╔══════════════════════════════════════════════════════════════╗\033[0m"
-    echo -e "\033[1;35m║         Big Bear Unicode Security Scanner v2.1.1 AI+         ║\033[0m"
+    echo -e "\033[1;35m║     Big Bear Unicode Security Scanner v${VERSION} AI+     ║\033[0m"
     echo -e "\033[1;35m║       Detecting dangerous Unicode & AI injection attacks      ║\033[0m"
     echo -e "\033[1;35m║                       Please support me!                     ║\033[0m"
     echo -e "\033[1;35m║               https://ko-fi.com/bigbeartechworld             ║\033[0m"

--- a/check-for-unicode/run.sh
+++ b/check-for-unicode/run.sh
@@ -211,6 +211,7 @@ is_common_unicode() {
     [[ "$unicode_code" =~ ^00B[239]$ ]] && return 0
     [[ "$unicode_code" =~ ^207[0-9]$ ]] && return 0
     # Subscript digits: U+2080-U+2089
+    # Note: ^208[0-9]$ also covers U+2085-U+2089 which are not currently in harmful_patterns
     [[ "$unicode_code" =~ ^208[0-9]$ ]] && return 0
     # Roman numerals: U+2160-U+217F, excluding Latin-lookalike confusables
     # (U+2160 I, U+2165 VI, U+2169 X, U+2174 v, U+2179 x remain detectable)


### PR DESCRIPTION
- Update version to 2026.03.0 across all references
- Expand `--exclude-common` flag to cover additional typography characters (soft hyphens, superscripts, subscripts, Roman numerals, combining diacritical marks, replacement character)
- Reduce false positives in documentation and markdown repositories
- Improve help text clarity for the `--exclude-common` option

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the scanner version to `2026.03.0`, expands `is_common_unicode()` with new exclusions for superscript digits, subscript digits, and non-confusable Roman numerals, and updates the help text and banner accordingly.

**Key observations:**
- The version bump and dynamic banner (`v${VERSION}`) are applied consistently across the comment header, `VERSION` variable, and display output. The banner padding has been adjusted to 7 spaces on each side, producing a correct 62-character inner width for the `2026.03.0` version string.
- The new `is_common_unicode()` exclusions correctly implement the described intent: superscripts (`^00B[239]$`, `^207[0-9]$`), subscripts (`^208[0-9]$`), and Roman numerals (`^21[67][0-9A-F]$`) are all treated as common, while the five explicitly confusable Roman numerals (U+2160, U+2165, U+2169, U+2174, U+2179) are correctly preserved as detectable via the negated guard `[[ ! "$unicode_code" =~ ^(2160|2165|2169|2174|2179)$ ]]`.
- The updated help text now includes an inline note `(note: also suppresses some AI-confusion and homograph checks)`, which is a meaningful transparency improvement over the old `(very permissive)` label.
- All of the new exclusions (`^207[0-9]$`, `^208[0-9]$`, `^21[67][0-9A-F]$`) over-cover the actual `harmful_patterns` population by design (the excess codes are not in `harmful_patterns` and are therefore functionally inert), and the inline comments acknowledge this explicitly.
- Multiple previous review threads have raised concerns about the security trade-offs of expanding `--exclude-common`; those issues remain open and are not repeated here.

<h3>Confidence Score: 3/5</h3>

- The code logic is functionally correct but the expanded `--exclude-common` exclusions introduce documented trade-offs that suppress active security detections (AI-confusion superscripts/subscripts, confusable punctuation) and warrant review before merging.
- The version bump and banner changes are straightforward and correctly implemented. The new `is_common_unicode()` patterns are logically sound — the Roman numeral confusable-guard is correctly structured, regex ranges match their documented intent, and the over-inclusive subscript/superscript coverage is explicitly annotated. However, several of the newly excluded characters (`00B2`, `00B3`, `00B9`, `2070`–`2079`, `2080`–`2084`) are explicitly listed in `harmful_patterns` under the AI-confusion category, and multiple previous review threads have flagged unresolved concerns about silencing those detections. The framing shift from "very permissive" to "recommended for docs/markdown repos" may increase adoption of the flag among users who don't fully appreciate the trade-offs. Score reflects that while no new blocking bugs were introduced, the open concerns from prior threads around security coverage regression have not yet been resolved.
- The `is_common_unicode()` function in `check-for-unicode/run.sh` (lines 209–219) warrants careful review due to the interplay between the new exclusions and existing `harmful_patterns` entries.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| check-for-unicode/run.sh | Version bumped to 2026.03.0; `is_common_unicode()` expanded with superscript/subscript/Roman-numeral exclusions that silence entries already present in `harmful_patterns`; help text and banner updated. The exclusion logic is functionally correct but intentionally silences several AI-confusion and confusable-character detections when `--exclude-common` is active. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Character from harmful_patterns] --> B{--exclude-common\nflag active?}
    B -- No --> Z[Run detection check]
    B -- Yes --> C{is_common_unicode?}

    C -- Smart quotes\nU+2018/19/1C/1D --> SKIP[Skip / no alert]
    C -- Dashes\nU+2010-2015 --> SKIP
    C -- Ellipsis U+2026 --> SKIP
    C -- Common spaces\nU+2007-200A --> SKIP
    C -- Angle quotes\nU+2039/203A --> SKIP
    C -- Per mille U+2030 --> SKIP

    C -- Superscripts\nU+00B2/B3/B9\nU+2070-2079 --> SKIP
    C -- Subscripts\nU+2080-2089 --> SKIP

    C -- Roman numerals\nU+2160-217F\nexcl. 2160/2165/2169/2174/2179 --> SKIP

    C -- Confusable Roman numerals\n2160 I, 2165 VI, 2169 X\n2174 v, 2179 x --> Z
    C -- No match --> Z

    Z --> R{Pattern found\nin file?}
    R -- Yes --> ALERT[Report finding]
    R -- No --> NEXT[Next pattern]

    style SKIP fill:#f96,color:#000
    style ALERT fill:#f33,color:#fff
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `check-for-unicode/run.sh`, line 75 ([link](https://github.com/bigbeartechworld/big-bear-scripts/blob/f32e56e8bf46148c8f724aa58f02635bbdc1e38c/check-for-unicode/run.sh#L75)) 

   **Stale example comment**

   The `--exclude-common` help text (lines 56–58) was updated to remove "very permissive" in favor of "recommended for docs/markdown repos," but this example still uses the old phrasing. Update for consistency:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: check-for-unicode/run.sh
   Line: 75

   Comment:
   **Stale example comment**

   The `--exclude-common` help text (lines 56–58) was updated to remove "very permissive" in favor of "recommended for docs/markdown repos," but this example still uses the old phrasing. Update for consistency:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `check-for-unicode/run.sh`, line 75 ([link](https://github.com/bigbeartechworld/big-bear-scripts/blob/ba7022858987039f3dc89d2d447f25bd09f46e07/check-for-unicode/run.sh#L75)) 

   The inline comment on this example contradicts the updated help text. The help describes the flag as "recommended for docs/markdown repos" (line 58), but this example labels it "Very permissive for documentation"—a different framing that could confuse users.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: check-for-unicode/run.sh
   Line: 75

   Comment:
   The inline comment on this example contradicts the updated help text. The help describes the flag as "recommended for docs/markdown repos" (line 58), but this example labels it "Very permissive for documentation"—a different framing that could confuse users.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Last reviewed commit: b93595d</sub>

<!-- /greptile_comment -->