### PR TITLE
🚀 feat: Add database migrations to startup

### DIFF
--- a/start-pterodactyl-panel/run.sh
+++ b/start-pterodactyl-panel/run.sh
@@ -11,7 +11,10 @@ log() {
 
 generate_key() {
     log "Generating key..."
-    docker exec -i $CONTAINER_ID php artisan key:generate --force
+    if ! docker exec -i $CONTAINER_ID php artisan key:generate --force; then
+        log "ERROR: Key generation failed. Aborting."
+        exit 1
+    fi
     log "Key generated successfully."
 }
 
@@ -26,7 +29,10 @@ run_migrations() {
 
 optimize_cache() {
     log "Optimizing Laravel cache..."
-    docker exec -i $CONTAINER_ID php artisan optimize
+    if ! docker exec -i $CONTAINER_ID php artisan optimize; then
+        log "ERROR: Cache optimization failed. Aborting."
+        exit 1
+    fi
     log "Laravel cache optimized successfully."
 }
 

--- a/start-pterodactyl-panel/run.sh
+++ b/start-pterodactyl-panel/run.sh
@@ -15,6 +15,12 @@ generate_key() {
     log "Key generated successfully."
 }
 
+run_migrations() {
+    log "Running database migrations..."
+    docker exec -it $CONTAINER_ID php artisan migrate --force
+    log "Database migrations completed successfully."
+}
+
 optimize_cache() {
     log "Optimizing Laravel cache..."
     docker exec -it $CONTAINER_ID php artisan optimize
@@ -38,6 +44,7 @@ create_user() {
 main() {
     log "Starting script..."
     generate_key
+    run_migrations
     optimize_cache
     prompt_check_login
     create_user

--- a/start-pterodactyl-panel/run.sh
+++ b/start-pterodactyl-panel/run.sh
@@ -11,13 +11,13 @@ log() {
 
 generate_key() {
     log "Generating key..."
-    docker exec -it $CONTAINER_ID php artisan key:generate --force
+    docker exec -i $CONTAINER_ID php artisan key:generate --force
     log "Key generated successfully."
 }
 
 run_migrations() {
     log "Running database migrations..."
-    if ! docker exec -it $CONTAINER_ID php artisan migrate --force; then
+    if ! docker exec -i $CONTAINER_ID php artisan migrate --force; then
         log "ERROR: Database migrations failed. Aborting."
         exit 1
     fi
@@ -26,7 +26,7 @@ run_migrations() {
 
 optimize_cache() {
     log "Optimizing Laravel cache..."
-    docker exec -it $CONTAINER_ID php artisan optimize
+    docker exec -i $CONTAINER_ID php artisan optimize
     log "Laravel cache optimized successfully."
 }
 

--- a/start-pterodactyl-panel/run.sh
+++ b/start-pterodactyl-panel/run.sh
@@ -17,7 +17,10 @@ generate_key() {
 
 run_migrations() {
     log "Running database migrations..."
-    docker exec -it $CONTAINER_ID php artisan migrate --force
+    if ! docker exec -it $CONTAINER_ID php artisan migrate --force; then
+        log "ERROR: Database migrations failed. Aborting."
+        exit 1
+    fi
     log "Database migrations completed successfully."
 }
 


### PR DESCRIPTION
- Add database migrations execution to panel startup process
- Ensure database schema is properly initialized before application starts
- Run migrations with --force flag for non-interactive execution in containerized environments

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `run_migrations` step to the Pterodactyl panel startup script and simultaneously applies consistent error-handling across all `docker exec` calls. The changes are well-structured and address the concerns raised in the previous review round.

**Key changes:**
- **New `run_migrations` function** runs `php artisan migrate --force` and aborts the script on failure — correctly placed between key generation and cache optimization.
- **`generate_key` and `optimize_cache`** both had their `-it` flag replaced with `-i` (correct for non-interactive container commands) and gained the same fail-fast error handling pattern.
- **`create_user`** (unchanged by this PR) still uses `docker exec -it` which is appropriate for an interactive prompt, but its success log remains unconditional — a minor pre-existing inconsistency worth cleaning up in a follow-up.

<h3>Confidence Score: 4/5</h3>

- Safe to merge; all prior review concerns are fully resolved and the new migration step is correctly implemented.
- All previously flagged issues (unconditional success log in `run_migrations`, inconsistent error handling in `generate_key` and `optimize_cache`) are addressed. The only remaining item is a pre-existing inconsistency in the unchanged `create_user` function, which is a non-blocking style issue.
- No files require special attention. The single changed file looks correct.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| start-pterodactyl-panel/run.sh | Adds `run_migrations` with proper error handling, fixes `-it` → `-i` for non-interactive steps, and inserts migrations between key generation and cache optimization. One pre-existing inconsistency remains in `create_user` (unconditional success log), not introduced by this PR. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([Start run.sh]) --> B[generate_key\nartisan key generate]
    B -->|failure| C[log ERROR and exit 1]
    B -->|success| D[run_migrations\nartisan migrate --force]
    D -->|failure| E[log ERROR and exit 1]
    D -->|success| F[optimize_cache\nartisan optimize]
    F -->|failure| G[log ERROR and exit 1]
    F -->|success| H[prompt_check_login]
    H --> I{Create user?}
    I -->|No| J([Script finished])
    I -->|Yes| K[create_user\nartisan p:user:make]
    K --> J
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `start-pterodactyl-panel/run.sh`, line 48-50 ([link](https://github.com/bigbeartechworld/big-bear-scripts/blob/c33f81fbfaf5640eb18155b7e5c6d9735f1f7eb1/start-pterodactyl-panel/run.sh#L48-L50)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`create_user` success log is unconditional**

   The `create_user` function still logs `"User created successfully."` regardless of whether the `docker exec -it` call on line 48 actually succeeded. This is a pre-existing inconsistency, but since the rest of the script now has uniform error handling after this PR, it stands out more. Applying the same guard pattern keeps the script consistent:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: start-pterodactyl-panel/run.sh
   Line: 48-50

   Comment:
   **`create_user` success log is unconditional**

   The `create_user` function still logs `"User created successfully."` regardless of whether the `docker exec -it` call on line 48 actually succeeded. This is a pre-existing inconsistency, but since the rest of the script now has uniform error handling after this PR, it stands out more. Applying the same guard pattern keeps the script consistent:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: start-pterodactyl-panel/run.sh
Line: 48-50

Comment:
**`create_user` success log is unconditional**

The `create_user` function still logs `"User created successfully."` regardless of whether the `docker exec -it` call on line 48 actually succeeded. This is a pre-existing inconsistency, but since the rest of the script now has uniform error handling after this PR, it stands out more. Applying the same guard pattern keeps the script consistent:

```suggestion
    if [[ $REPLY =~ ^[Yy]$ ]]; then
        log "Creating a user..."
        if ! docker exec -it $CONTAINER_ID php artisan p:user:make; then
            log "ERROR: User creation failed."
            exit 1
        fi
        log "User created successfully."
    fi
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["🛡️ fix: add error h..."](https://github.com/bigbeartechworld/big-bear-scripts/commit/c33f81fbfaf5640eb18155b7e5c6d9735f1f7eb1)</sub>

<!-- /greptile_comment -->