### PR TITLE
refactor(pterodactyl):✨ Remove manual migration step

### DIFF
--- a/start-pterodactyl-panel/run.sh
+++ b/start-pterodactyl-panel/run.sh
@@ -18,15 +18,6 @@ generate_key() {
     log "Key generated successfully."
 }
 
-run_migrations() {
-    log "Running database migrations..."
-    if ! docker exec -i $CONTAINER_ID php artisan migrate --force; then
-        log "ERROR: Database migrations failed. Aborting."
-        exit 1
-    fi
-    log "Database migrations completed successfully."
-}
-
 optimize_cache() {
     log "Optimizing Laravel cache..."
     if ! docker exec -i $CONTAINER_ID php artisan optimize; then
@@ -53,7 +44,6 @@ create_user() {
 main() {
     log "Starting script..."
     generate_key
-    run_migrations
     optimize_cache
     prompt_check_login
     create_user


### PR DESCRIPTION
- Removed `run_migrations` function from startup script
- Database migrations now handled automatically by application during initialization
- Simplified startup process and eliminated redundant operations

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `run_migrations()` function and its invocation from `start-pterodactyl-panel/run.sh`, simplifying the startup script by relying on the Pterodactyl Panel container to handle migrations automatically during initialization.

**Key observations:**
- This change directly reverses PR #75 (`10776ae`), which was merged immediately before this PR by the **same author**, and whose commit message explicitly stated that the migration step was necessary to ensure the database schema is properly initialized before the application starts.
- The PR description asserts that "Database migrations now handled automatically by application during initialization," but provides no reference to which Docker image version introduced this behavior or where that entrypoint logic lives.
- If the target Docker image does **not** run `php artisan migrate --force` in its entrypoint, removing this step will leave fresh Pterodactyl installations with an unmigrated database, causing runtime failures.
- The `optimize_cache` step (which is kept) also depends on a properly migrated database, so it could fail silently in the absence of migrations.

<h3>Confidence Score: 3/5</h3>

- Risky to merge without verification that the Pterodactyl Panel Docker image actually runs migrations automatically on startup.
- The change reverses a deliberate, recently merged addition (PR #75) by the same author. The correctness of removing the explicit migration step hinges entirely on an unverified claim about Docker container entrypoint behavior. If the claim is wrong, fresh installations will have an unmigrated database and the panel will fail at runtime — a user-facing, first-time-setup-breaking bug.
- start-pterodactyl-panel/run.sh — the sole changed file; needs confirmation that the target Docker image handles migrations in its entrypoint before this removal is safe.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| start-pterodactyl-panel/run.sh | Removes `run_migrations()` and its `main()` call, reversing PR #75 by the same author. The correctness of this change depends entirely on whether the Pterodactyl Panel Docker image runs migrations automatically in its entrypoint — which is unverified. |

</details>


</details>


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User runs run.sh] --> B[Container starts\nmigrations claimed auto-handled]
    B --> C[generate_key\nartisan key generate]
    C -- success --> D{run_migrations\nREMOVED in this PR}
    D --> E[optimize_cache\nartisan optimize]
    E -- success --> F[prompt_check_login]
    F --> G{Create user?}
    G -- yes --> H[artisan p:user:make]
    G -- no --> I[Script finished]
    H --> I
    C -- failure --> X[Exit 1]
    E -- failure --> X
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `start-pterodactyl-panel/run.sh`, line 44-50 ([link](https://github.com/bigbeartechworld/big-bear-scripts/blob/580ba42a0005ca71895daf8ca5bcbeae38cff615/start-pterodactyl-panel/run.sh#L44-L50)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Migration step reversal without documented justification**

   This PR directly reverses PR #75 by the same author, which was committed just prior (`10776ae`) with the explicit motivation: *"This ensures the database schema is properly initialized before the application starts."*

   The current PR claims migrations are now handled automatically during container initialization — but the Pterodactyl Panel Docker image's entrypoint behavior is not referenced or verified anywhere. If the container does **not** run `php artisan migrate --force` in its own entrypoint, removing this step will leave fresh installations with an unmigrated database, causing the panel to fail at runtime (missing tables, etc.).

   Key questions to resolve before merging:
   1. Which specific Docker image / tag is being targeted, and does its entrypoint actually execute migrations?
   2. If migrations are auto-run by the container, why did PR #75 need to add them in the first place — what changed?

   If the Docker image truly handles migrations automatically, it would be helpful to add a short inline comment explaining this so future contributors don't re-add the step:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: start-pterodactyl-panel/run.sh
   Line: 44-50

   Comment:
   **Migration step reversal without documented justification**

   This PR directly reverses PR #75 by the same author, which was committed just prior (`10776ae`) with the explicit motivation: *"This ensures the database schema is properly initialized before the application starts."*

   The current PR claims migrations are now handled automatically during container initialization — but the Pterodactyl Panel Docker image's entrypoint behavior is not referenced or verified anywhere. If the container does **not** run `php artisan migrate --force` in its own entrypoint, removing this step will leave fresh installations with an unmigrated database, causing the panel to fail at runtime (missing tables, etc.).

   Key questions to resolve before merging:
   1. Which specific Docker image / tag is being targeted, and does its entrypoint actually execute migrations?
   2. If migrations are auto-run by the container, why did PR #75 need to add them in the first place — what changed?

   If the Docker image truly handles migrations automatically, it would be helpful to add a short inline comment explaining this so future contributors don't re-add the step:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: start-pterodactyl-panel/run.sh
Line: 44-50

Comment:
**Migration step reversal without documented justification**

This PR directly reverses PR #75 by the same author, which was committed just prior (`10776ae`) with the explicit motivation: *"This ensures the database schema is properly initialized before the application starts."*

The current PR claims migrations are now handled automatically during container initialization — but the Pterodactyl Panel Docker image's entrypoint behavior is not referenced or verified anywhere. If the container does **not** run `php artisan migrate --force` in its own entrypoint, removing this step will leave fresh installations with an unmigrated database, causing the panel to fail at runtime (missing tables, etc.).

Key questions to resolve before merging:
1. Which specific Docker image / tag is being targeted, and does its entrypoint actually execute migrations?
2. If migrations are auto-run by the container, why did PR #75 need to add them in the first place — what changed?

If the Docker image truly handles migrations automatically, it would be helpful to add a short inline comment explaining this so future contributors don't re-add the step:

```suggestion
main() {
    log "Starting script..."
    # Key generation must be explicit; migrations are handled by the container entrypoint.
    generate_key
    optimize_cache
    prompt_check_login
    create_user
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["refactor(pterodactyl..."](https://github.com/bigbeartechworld/big-bear-scripts/commit/580ba42a0005ca71895daf8ca5bcbeae38cff615)</sub>

<!-- /greptile_comment -->