### PR TITLE
🔧 fix: add MariaDB external_id column fix

### DIFF
--- a/start-pterodactyl-panel/run.sh
+++ b/start-pterodactyl-panel/run.sh
@@ -2,6 +2,7 @@
 
 LOG_FILE="pterodactyl_panel_log.txt"
 CONTAINER_ID="pterodactyl-panel"
+DB_CONTAINER_ID="big-bear-pterodactyl-panel-database-1"
 
 log() {
     local message="$1"
@@ -27,6 +28,15 @@ optimize_cache() {
     log "Laravel cache optimized successfully."
 }
 
+fix_external_id() {
+    log "Fixing external_id column for MariaDB compatibility..."
+    if docker exec -i $DB_CONTAINER_ID mysql -u pterodactyl -pcasaos panel -e "ALTER TABLE users MODIFY external_id varchar(191) DEFAULT NULL;" 2>/dev/null; then
+        log "external_id column fixed successfully."
+    else
+        log "WARNING: Could not fix external_id column. User creation may fail."
+    fi
+}
+
 prompt_check_login() {
     echo "Please check your website URL to see if it shows the login." | tee -a $LOG_FILE
 }
@@ -45,6 +55,7 @@ main() {
     log "Starting script..."
     generate_key
     optimize_cache
+    fix_external_id
     prompt_check_login
     create_user
     log "Script finished."


### PR DESCRIPTION
- Add database container ID variable
- Implement `fix_external_id` function to modify the external_id column for MariaDB compatibility
- Execute the fix during panel startup before user creation
- Resolve user creation failures by ensuring column definition matches MariaDB requirements

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `fix_external_id()` function to `start-pterodactyl-panel/run.sh` that runs an `ALTER TABLE` statement against the MariaDB container to resize the `external_id` column to `varchar(191)`, resolving a known MariaDB incompatibility that caused user creation to fail. The fix is called during panel startup, just before the interactive user-creation step.

- The new `fix_external_id()` function executes an `ALTER TABLE users MODIFY external_id varchar(191) DEFAULT NULL` query directly against the database container and logs a non-fatal warning if it fails.
- A new `DB_CONTAINER_ID` variable is introduced, hardcoded to the expected CasaOS container name `big-bear-pterodactyl-panel-database-1`.
- **Security concern**: The database password is passed inline as a CLI flag (`-p<password>`), which exposes it in the OS process list to any user who runs `ps aux` during script execution.
- **Portability concern**: Both the container name and the password are hardcoded defaults; users who customised either value will silently get the "WARNING" path with no actionable error — potentially leaving the underlying schema issue unfixed.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for default CasaOS deployments, but the hardcoded password exposed in the process list and silent failure for non-default installs warrant fixes before wider distribution.
- The fix correctly addresses the MariaDB external_id compatibility issue and is non-destructive (ALTER TABLE on an already-correct column is a no-op). However, the password is passed as a CLI argument making it visible in process listings, and the hardcoded default value means any user with a customised MariaDB password will silently get a no-op with just a WARNING log — the exact failure mode this PR is trying to prevent. These two issues together represent reliability and security concerns worth resolving.
- start-pterodactyl-panel/run.sh — hardcoded credential passed as a CLI flag on line 33

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| start-pterodactyl-panel/run.sh | Adds fix_external_id() to run ALTER TABLE before user creation; introduces a hardcoded default DB password exposed in the process argument list (visible via ps aux), and the fix silently no-ops for any user with a non-default MariaDB password. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([main starts]) --> B[generate_key]
    B -- error --> X1([exit 1])
    B -- ok --> C[optimize_cache]
    C -- error --> X2([exit 1])
    C -- ok --> D[fix_external_id\nNEW: ALTER TABLE users\nMODIFY external_id varchar 191]
    D -- success --> E[prompt_check_login]
    D -- failure --> F[log WARNING]
    F --> E
    E --> G{create_user\nPrompt y or n}
    G -- yes --> H[php artisan p:user:make]
    H --> I([Script finished])
    G -- no --> I
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: start-pterodactyl-panel/run.sh
Line: 33

Comment:
**Password exposed in process listing**

Passing the password directly as `-pcasaos` appends it to the process argument list, making it visible to any user on the host who runs `ps aux` or similar tools during the script's execution. This is a known MySQL/MariaDB anti-pattern and leaks credentials at the OS level.

A safer approach is to pass the password via an environment variable using `--defaults-extra-file` or through `MYSQL_PWD`:

```suggestion
    if docker exec -i $DB_CONTAINER_ID bash -c "MYSQL_PWD=casaos mysql -u pterodactyl panel -e \"ALTER TABLE users MODIFY external_id varchar(191) DEFAULT NULL;\"" 2>/dev/null; then
```

Or alternatively, read the password from the Pterodactyl `.env` file if it is accessible from inside the panel container, so the credential isn't hardcoded here at all.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: start-pterodactyl-panel/run.sh
Line: 33

Comment:
**Unquoted variable in `docker exec` call**

`$DB_CONTAINER_ID` (and `$CONTAINER_ID` used throughout the script) should be double-quoted to prevent word-splitting if the variable ever contains spaces or special characters.

```suggestion
    if docker exec -i "$DB_CONTAINER_ID" bash -c "MYSQL_PWD=casaos mysql -u pterodactyl panel -e \"ALTER TABLE users MODIFY external_id varchar(191) DEFAULT NULL;\"" 2>/dev/null; then
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: start-pterodactyl-panel/run.sh
Line: 5

Comment:
**Hardcoded default password won't work for non-default installs**

The database password baked into line 33 is only the default for this CasaOS template. Any user who has changed their MariaDB password will silently receive `WARNING: Could not fix external_id column. User creation may fail.` with no clear explanation of the root cause.

Consider reading the actual password from the panel's `.env` file at runtime (e.g. by `docker exec`-ing into the panel container and parsing the env file), then falling back to the default. This makes the fix robust for both default and customised installations and keeps credentials out of the script source.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["🔧 fix: add MariaDB external_id column f..."](https://github.com/bigbeartechworld/big-bear-scripts/commit/e541db0f679d4dc9c76f6dcae0ba67e33b069dff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25979688)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->